### PR TITLE
ビルドイベントがリソースファイルを更新しないように

### DIFF
--- a/ExtremeRoles/ExtremeRoles.csproj
+++ b/ExtremeRoles/ExtremeRoles.csproj
@@ -50,6 +50,6 @@
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
       <Exec Command="python $(SolutionDir)\convertToJson.py" />
       <Exec Command="if not exist $(SolutionDir)ExtremeRoles\Resources\Asset mkdir $(SolutionDir)ExtremeRoles\Resources\Asset" />
-      <Exec Command="xcopy $(SolutionDir)UnityAsset\ExtremeRoles $(SolutionDir)ExtremeRoles\Resources\Asset /y /i" />
+      <Exec Command="robocopy /mir $(SolutionDir)UnityAsset\ExtremeRoles $(SolutionDir)ExtremeRoles\Resources\Asset &amp; if errorlevel 8 (exit 1) else (exit 0)" />
     </Target>
 </Project>

--- a/ExtremeSkins/ExtremeSkins.csproj
+++ b/ExtremeSkins/ExtremeSkins.csproj
@@ -52,7 +52,7 @@
     </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="if not exist $(SolutionDir)ExtremeSkins\Resources\Asset mkdir $(SolutionDir)ExtremeSkins\Resources\Asset" />
-    <Exec Command="xcopy $(SolutionDir)UnityAsset\ExtremeSkins $(SolutionDir)ExtremeSkins\Resources\Asset /y /i" />
+    <Exec Command="robocopy /mir $(SolutionDir)UnityAsset\ExtremeSkins $(SolutionDir)ExtremeSkins\Resources\Asset &amp; if errorlevel 8 (exit 1) else (exit 0)" />
   </Target>
     <Target Name="Copy" AfterTargets="Build" Condition="'$(AmongUs)' != ''">
       <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(AmongUs)/BepInEx/plugins/" UseSymboliclinksIfPossible="true" />

--- a/convertToJson.py
+++ b/convertToJson.py
@@ -1,5 +1,6 @@
 import os
 import json
+import tempfile
 from openpyxl import load_workbook
 
 WORKING_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -9,6 +10,25 @@ EXTREMERORLS_OUT_FILE = os.path.join(WORKING_DIR, "ExtremeRoles", "Resources", "
 
 EXTREMESKIN_IN_FILE = os.path.join(WORKING_DIR, "ExtremeSkinsTransData.xlsx")
 EXTREMESKIN_OUT_FILE = os.path.join(WORKING_DIR, "ExtremeSkins", "Resources", "LangData", "stringData.json")
+
+def writeJsonIfNeed(stringData, outputFile, **kwargs):
+  with tempfile.TemporaryFile("w+") as f:
+    json.dump(stringData, f, **kwargs)
+    f.seek(0)
+    currentdata=f.read()
+  try:
+    with open(outputFile, "r") as f:
+      olddata=f.read()
+  except Exception:
+    need = True
+  else:
+    need = currentdata!=olddata
+
+  if need:
+    os.makedirs(os.path.dirname(outputFile), exist_ok=True)
+    with open(outputFile, "w") as f:
+      f.write(currentdata)
+
 
 def stringToJson(filename, outputFile):
   wb = load_workbook(filename, read_only = True)
@@ -37,10 +57,7 @@ def stringToJson(filename, outputFile):
       if data:
         stringData[name] = data
 
-  os.makedirs(os.path.dirname(outputFile), exist_ok=True)
-
-  with open(outputFile, "w") as f:
-    json.dump(stringData, f, indent=4)
+  writeJsonIfNeed(stringData, outputFile, indent=4)
 
 if __name__ == "__main__":
   stringToJson(EXTREMERORLS_IN_FILE, EXTREMERORLS_OUT_FILE)

--- a/convertToJson.py
+++ b/convertToJson.py
@@ -53,7 +53,6 @@ def stringToJson(filename, outputFile):
     os.makedirs(os.path.dirname(outputFile), exist_ok=True)
     with open(outputFile, "w") as f:
       json.dump(stringData, f, indent=4)
-      print(outputFile)
 
 if __name__ == "__main__":
   stringToJson(EXTREMERORLS_IN_FILE, EXTREMERORLS_OUT_FILE)

--- a/convertToJson.py
+++ b/convertToJson.py
@@ -44,7 +44,7 @@ def stringToJson(filename, outputFile):
       for i, string in enumerate(row[1:]):
         if string.value:
           # I hate excel why did I do this to myself
-          data[i] = string.value.replace("\r", "").replace("_x000D_", "").replace("\\n", "\n")
+          data[str(i)] = string.value.replace("\r", "").replace("_x000D_", "").replace("\\n", "\n")
 
       if data:
         stringData[name] = data

--- a/convertToJson.py
+++ b/convertToJson.py
@@ -1,6 +1,5 @@
 import os
 import json
-import tempfile
 from openpyxl import load_workbook
 
 WORKING_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -11,23 +10,16 @@ EXTREMERORLS_OUT_FILE = os.path.join(WORKING_DIR, "ExtremeRoles", "Resources", "
 EXTREMESKIN_IN_FILE = os.path.join(WORKING_DIR, "ExtremeSkinsTransData.xlsx")
 EXTREMESKIN_OUT_FILE = os.path.join(WORKING_DIR, "ExtremeSkins", "Resources", "LangData", "stringData.json")
 
-def writeJsonIfNeed(stringData, outputFile, **kwargs):
-  with tempfile.TemporaryFile("w+") as f:
-    json.dump(stringData, f, **kwargs)
-    f.seek(0)
-    currentdata=f.read()
+def isRequireUpdate(newJson, outputFile):
   try:
     with open(outputFile, "r") as f:
-      olddata=f.read()
+      oldJson = json.load(f)
+    oldJsonStr = json.dumps(oldJson)
   except Exception:
-    need = True
+    return True
   else:
-    need = currentdata!=olddata
-
-  if need:
-    os.makedirs(os.path.dirname(outputFile), exist_ok=True)
-    with open(outputFile, "w") as f:
-      f.write(currentdata)
+    newJsonStr = json.dumps(newJson)
+    return oldJsonStr != newJsonStr
 
 
 def stringToJson(filename, outputFile):
@@ -57,7 +49,11 @@ def stringToJson(filename, outputFile):
       if data:
         stringData[name] = data
 
-  writeJsonIfNeed(stringData, outputFile, indent=4)
+  if isRequireUpdate(stringData, outputFile):
+    os.makedirs(os.path.dirname(outputFile), exist_ok=True)
+    with open(outputFile, "w") as f:
+      json.dump(stringData, f, indent=4)
+      print(outputFile)
 
 if __name__ == "__main__":
   stringToJson(EXTREMERORLS_IN_FILE, EXTREMERORLS_OUT_FILE)


### PR DESCRIPTION
## issueへのリンク
<!-- このPull requestによって修正される不具合または追加機能について議論されているissueの番号を＃をつけて記載、ない場合は修正される不具合または追加機能についてのissueを作成した上でPull requestをお願いします 例:#7 -->
issue #245

## レビュワーに確認してほしいこと
<!-- このコードを見る全ての人(主にyukieiji)に対して確認してほしい事 -->
- 3回目以降のソリューションのビルド時に「成功 0, 最新の状態 3」になる
- UnityAssertか\*.Trans.xlsxを更新してリビルドをした際に、変更点がソフトに組み込まれる
手元では `ExtremeRoles\Resources` が更新されることは確認しています。

## チェックリスト
<!-- 以下のチェックリストはほぼマストです。確認をお願いします -->
- [] : ホストで追加する機能や役職、能力が使えることを確認した
- [] : ホスト以外で追加する機能や役職、能力が使えることを確認した
- [] : 役職の能力に関して会議が挟まる、サイドキックにされる等で正しくリセットされることを確認した

### 追加チェックリスト
<!-- これはコードの品質を保つためのチェックリストです、やってなくても構いません -->
- [] : 変数名に代入される値は妥当であるか
- [] : メソッド、関数名に相応しくない処理をしていないか
- [] : メソッド、関数は長くなりすぎてないか
- [] : 機能や役職の変数、メソッドのアクセシビリティレベルは妥当であるか(publicを多用していないか)
- [] : 機能や役職のデータ構造は妥当だと思われるものを使用しているか
