### PR TITLE
シオンが召喚するダミープレイヤーの名前の区切り文字をハイフンに変更する

### DIFF
--- a/ExtremeRoles/Roles/Solo/Host/Xion.Keyboard.cs
+++ b/ExtremeRoles/Roles/Solo/Host/Xion.Keyboard.cs
@@ -30,7 +30,7 @@ public sealed partial class Xion
             GameSystem.IsLobby &&
             IsAllPlyerDummy())
         {
-            GameSystem.SpawnDummyPlayer($"XionDummy_{randomString(10)}");
+            GameSystem.SpawnDummyPlayer($"XionDummy-{randomString(10)}");
         }
     }
 


### PR DESCRIPTION
シオンが召喚するダミープレイヤーの名前を`XionDummy_{ランダム文字列}`から、`XionDummy-{ランダム文字列}`に変更します。

アンダースコア`_`はAmong UsのチャットUIで入力できない文字のため、ハイフン`-`に変更することで、シオンが使用できるローカルゲーム専用コマンドの`/SetRole`でダミープレイヤーの名前を指定することができるようになります。

軽微な変更のため、ビルドしての動作確認をしていません（要望があればします）。

## issueへのリンク
<!-- このPull requestによって修正される不具合または追加機能について議論されているissueの番号を＃をつけて記載、ない場合は修正される不具合または追加機能についてのissueを作成した上でPull requestをお願いします 例:#7 -->

- close #349 

## レビュワーに確認してほしいこと
<!-- このコードを見る全ての人(主にyukieiji)に対して確認してほしい事 -->

## チェックリスト
<!-- 以下のチェックリストはほぼマストです。確認をお願いします -->
- [] : ホストで追加する機能や役職、能力が使えることを確認した
- [] : ホスト以外で追加する機能や役職、能力が使えることを確認した
- [] : 役職の能力に関して会議が挟まる、サイドキックにされる等で正しくリセットされることを確認した

### 追加チェックリスト
<!-- これはコードの品質を保つためのチェックリストです、やってなくても構いません -->
- [] : 変数名に代入される値は妥当であるか
- [] : メソッド、関数名に相応しくない処理をしていないか
- [] : メソッド、関数は長くなりすぎてないか
- [] : 機能や役職の変数、メソッドのアクセシビリティレベルは妥当であるか(publicを多用していないか)
- [] : 機能や役職のデータ構造は妥当だと思われるものを使用しているか
