### PR TITLE
[WIP] combinationフォルダ以下のコードをリファクタリング

### DIFF
--- a/ExtremeRoles/Roles/Combination/Accelerator.cs
+++ b/ExtremeRoles/Roles/Combination/Accelerator.cs
@@ -78,8 +78,11 @@ public sealed class Accelerator :
         byte rolePlayerId = reader.ReadByte();
 
         var rolePlayer = Player.GetPlayerControlById(rolePlayerId);
-        var role = ExtremeRoleManager.GetSafeCastedRole<Accelerator>(rolePlayerId);
-        if (role == null || rolePlayer == null) { return; }
+        if (rolePlayer == null ||
+			!ExtremeRoleManager.TryGetSafeCastedRole<Accelerator>(rolePlayerId, out var role))
+		{
+			return;
+		}
 
         float x = reader.ReadSingle();
         float y = reader.ReadSingle();

--- a/ExtremeRoles/Roles/Combination/Avalon.cs
+++ b/ExtremeRoles/Roles/Combination/Avalon.cs
@@ -66,9 +66,13 @@ public sealed class Assassin : MultiAssignRoleBase
     public override bool TryRolePlayerKilledFrom(
         PlayerControl rolePlayer, PlayerControl fromPlayer)
     {
-        if (!this.CanKilled) { return false; }
-
-        var fromPlayerRole = ExtremeRoleManager.GameRole[fromPlayer.PlayerId];
+        if (!(
+				this.CanKilled &&
+				ExtremeRoleManager.TryGetRole(fromPlayer.PlayerId, out var fromPlayerRole)
+			))
+		{
+			return false;
+		}
 
         if (fromPlayerRole.IsNeutral())
         {
@@ -338,9 +342,16 @@ public sealed class Marlin : MultiAssignRoleBase, IRoleSpecialSetUp, IRoleResetM
     {
         foreach (var(playerId, poolPlayer) in this.PlayerIcon)
         {
-            if (playerId == PlayerControl.LocalPlayer.PlayerId) { continue; }
+            if (playerId == PlayerControl.LocalPlayer.PlayerId)
+            {
+                continue;
+            }
 
-            SingleRoleBase role = ExtremeRoleManager.GameRole[playerId];
+            if (!ExtremeRoleManager.TryGetRole(playerId, out var role))
+            {
+                continue;
+            }
+
             if (role.IsCrewmate() ||
                 (role.IsNeutral() && !this.CanSeeNeutral) ||
                 (role.Id == ExtremeRoleId.Assassin && !this.canSeeAssassin))

--- a/ExtremeRoles/Roles/Combination/Guesser.cs
+++ b/ExtremeRoles/Roles/Combination/Guesser.cs
@@ -400,8 +400,10 @@ public sealed class Guesser :
         this.bulletNum = this.bulletNum - 1;
         this.curGuessNum = this.curGuessNum + 1;
 
-        var targetRole = ExtremeRoleManager.GameRole[playerId];
+        if (!ExtremeRoleManager.TryGetRole(playerId, out var targetRole))
         {
+            return;
+        }
 
         ExtremeRoleId roleId = targetRole.Id;
         ExtremeRoleId anotherRoleId = ExtremeRoleId.Null;

--- a/ExtremeRoles/Roles/Combination/Guesser.cs
+++ b/ExtremeRoles/Roles/Combination/Guesser.cs
@@ -401,6 +401,7 @@ public sealed class Guesser :
         this.curGuessNum = this.curGuessNum + 1;
 
         var targetRole = ExtremeRoleManager.GameRole[playerId];
+        {
 
         ExtremeRoleId roleId = targetRole.Id;
         ExtremeRoleId anotherRoleId = ExtremeRoleId.Null;

--- a/ExtremeRoles/Roles/Combination/Kids.cs
+++ b/ExtremeRoles/Roles/Combination/Kids.cs
@@ -230,9 +230,7 @@ public sealed class Delinquent : MultiAssignRoleBase, IRoleAutoBuildAbility
 		AbilityType abilityType = (AbilityType)reader.ReadByte();
 		byte playerId = reader.ReadByte();
 
-		Delinquent? delinquent =
-            ExtremeRoleManager.GetSafeCastedRole<Delinquent>(playerId);
-		if (delinquent is null)
+		if (!ExtremeRoleManager.TryGetSafeCastedRole<Delinquent>(playerId, out var delinquent))
 		{
 			return;
 		}

--- a/ExtremeRoles/Roles/Combination/Lover.cs
+++ b/ExtremeRoles/Roles/Combination/Lover.cs
@@ -8,7 +8,6 @@ using AmongUs.GameOptions;
 using ExtremeRoles.Helper;
 using ExtremeRoles.Module;
 using ExtremeRoles.Roles.API;
-using ExtremeRoles.Performance;
 using ExtremeRoles.Extension.Player;
 using ExtremeRoles.Module.CustomOption.Interfaces;
 using ExtremeRoles.Module.CustomOption.Factory;
@@ -79,18 +78,19 @@ public sealed class Lover : MultiAssignRoleBase
 
         baseDesc = $"{baseDesc}\n{Tr.GetString("curLover")}:";
 
-        foreach (var item in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            if (this.IsSameControlId(item.Value))
+            if (playerControl == null || playerControl.Data == null ||
+                !ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				!this.IsSameControlId(role))
             {
-                string playerName = Player.GetPlayerControlById(
-                    item.Key).Data.PlayerName;
-                baseDesc += $"{playerName},"; ;
+                continue;
             }
+            baseDesc = $"{baseDesc}{playerControl.Data.PlayerName},";
         }
 
-        return baseDesc;
-    }
+		return baseDesc;
+	}
 
     public override void RolePlayerKilledAction(
         PlayerControl rolePlayer, PlayerControl killerPlayer)
@@ -215,13 +215,17 @@ public sealed class Lover : MultiAssignRoleBase
 
     public void ChangeAllLoverToNeutral()
     {
-        foreach (var item in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            if (this.IsSameControlId(item.Value))
+            if (playerControl == null ||
+				playerControl.Data == null ||
+                !ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				!this.IsSameControlId(role))
             {
-                item.Value.Team = ExtremeRoleType.Neutral;
-                item.Value.HasTask = false;
+                continue;
             }
+            role.Team = ExtremeRoleType.Neutral;
+            role.HasTask = false;
         }
     }
 
@@ -390,17 +394,21 @@ public sealed class Lover : MultiAssignRoleBase
 
     private void forceReplaceToNeutral(byte targetId)
     {
-        var newKiller = (Lover)ExtremeRoleManager.GameRole[targetId];
-        newKiller.Team = ExtremeRoleType.Neutral;
-        newKiller.CanKill = true;
-        newKiller.HasTask = false;
-        newKiller.HasOtherVision = newKiller.killerLoverHasOtherVision;
-        newKiller.Vision = newKiller.killerLoverVision;
-        newKiller.IsApplyEnvironmentVision = newKiller.killerLoverIsApplyEnvironmentVisionEffect;
-        newKiller.UseVent = newKiller.killerLoverCanUseVent;
-        newKiller.ChangeAllLoverToNeutral();
-        ExtremeRoleManager.GameRole[targetId] = newKiller;
-    }
+        if (!ExtremeRoleManager.TryGetSafeCastedRole<Lover>(targetId, out var newKiller))
+        {
+			return;
+        }
+
+		newKiller.Team = ExtremeRoleType.Neutral;
+		newKiller.CanKill = true;
+		newKiller.HasTask = false;
+		newKiller.HasOtherVision = newKiller.killerLoverHasOtherVision;
+		newKiller.Vision = newKiller.killerLoverVision;
+		newKiller.IsApplyEnvironmentVision = newKiller.killerLoverIsApplyEnvironmentVisionEffect;
+		newKiller.UseVent = newKiller.killerLoverCanUseVent;
+		newKiller.ChangeAllLoverToNeutral(); // This method iterates and modifies roles, ensure it's compatible with TryGetRole logic
+		ExtremeRoleManager.SetNewRole(targetId, newKiller);
+	}
 
     private string getTaskText(string baseString, bool isContainFakeTask)
     {
@@ -422,15 +430,18 @@ public sealed class Lover : MultiAssignRoleBase
 
         List<byte> alive = new List<byte>();
 
-        foreach(var (playerId, role) in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            var player = GameData.Instance.GetPlayerById(playerId);
-            if (this.IsSameControlId(role) &&
-                !player.IsDead &&
-                !player.Disconnected)
+            if (playerControl == null ||
+				playerControl.Data == null ||
+				playerControl.Data.IsDead ||
+				playerControl.Data.Disconnected ||
+                !ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				!this.IsSameControlId(role))
             {
-                alive.Add(playerId);
+                continue;
             }
+            alive.Add(playerControl.PlayerId);
         }
         return alive;
     }

--- a/ExtremeRoles/Roles/Combination/Lover.cs
+++ b/ExtremeRoles/Roles/Combination/Lover.cs
@@ -77,7 +77,7 @@ public sealed class Lover : MultiAssignRoleBase
         }
 
         baseDesc = $"{baseDesc}\n{Tr.GetString("curLover")}:";
-
+		var playerName = new List<string>();
         foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
             if (playerControl == null || playerControl.Data == null ||
@@ -86,10 +86,10 @@ public sealed class Lover : MultiAssignRoleBase
             {
                 continue;
             }
-            baseDesc = $"{baseDesc}{playerControl.Data.PlayerName},";
+			playerName.Add(playerControl.Data.PlayerName);
         }
 
-		return baseDesc;
+		return $"{baseDesc}{string.Join(",", playerName)}";
 	}
 
     public override void RolePlayerKilledAction(

--- a/ExtremeRoles/Roles/Combination/Mover.cs
+++ b/ExtremeRoles/Roles/Combination/Mover.cs
@@ -110,8 +110,11 @@ public sealed class Mover :
         byte rolePlayerId = reader.ReadByte();
 
         var rolePlayer = Player.GetPlayerControlById(rolePlayerId);
-        var role = ExtremeRoleManager.GetSafeCastedRole<Mover>(rolePlayerId);
-        if (role == null || rolePlayer == null) { return; }
+        if (rolePlayer == null ||
+			!ExtremeRoleManager.TryGetSafeCastedRole<Mover>(rolePlayerId, out var role))
+        {
+            return;
+        }
 
         float x = reader.ReadSingle();
         float y = reader.ReadSingle();

--- a/ExtremeRoles/Roles/Combination/Sharer.cs
+++ b/ExtremeRoles/Roles/Combination/Sharer.cs
@@ -149,18 +149,18 @@ public sealed class Sharer : MultiAssignRoleBase, IRoleMurderPlayerHook, IRoleRe
     {
         string baseDesc = $"{base.GetFullDescription()}\n{Tr.GetString("curSharer")}:";
 
-        foreach (var item in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            if (this.IsSameControlId(item.Value))
+            if (playerControl == null || playerControl.Data == null ||
+                !ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				!this.IsSameControlId(role))
             {
-                string playerName = Player.GetPlayerControlById(
-                    item.Key).Data.PlayerName;
-                baseDesc += $"{playerName},"; ;
+                continue;
             }
+            baseDesc = $"{baseDesc}{playerControl.Data.PlayerName},";
         }
-
-        return baseDesc;
-    }
+		return baseDesc;
+	}
 
     public override string GetIntroDescription()
     {
@@ -276,17 +276,21 @@ public sealed class Sharer : MultiAssignRoleBase, IRoleMurderPlayerHook, IRoleRe
 
     private List<byte> getAliveSameSharer()
     {
-        List<byte> alive = new List<byte>();
+        List<byte> alive = [];
 
-        foreach (var item in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            var player = GameData.Instance.GetPlayerById(item.Key);
-            if (this.IsSameControlId(item.Value) &&
-                (!player.IsDead || !player.Disconnected))
+            if (playerControl == null ||
+				playerControl.Data == null ||
+				playerControl.Data.IsDead ||
+				playerControl.Data.Disconnected ||
+				!ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				!this.IsSameControlId(role))
             {
-                alive.Add(item.Key);
+                continue;
             }
-        }
+			alive.Add(playerControl.PlayerId);
+		}
 
         return alive;
     }

--- a/ExtremeRoles/Roles/Combination/Sharer.cs
+++ b/ExtremeRoles/Roles/Combination/Sharer.cs
@@ -147,8 +147,7 @@ public sealed class Sharer : MultiAssignRoleBase, IRoleMurderPlayerHook, IRoleRe
 
     public override string GetFullDescription()
     {
-        string baseDesc = $"{base.GetFullDescription()}\n{Tr.GetString("curSharer")}:";
-
+		var player = new List<string>();
         foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
             if (playerControl == null || playerControl.Data == null ||
@@ -157,9 +156,9 @@ public sealed class Sharer : MultiAssignRoleBase, IRoleMurderPlayerHook, IRoleRe
             {
                 continue;
             }
-            baseDesc = $"{baseDesc}{playerControl.Data.PlayerName},";
+			player.Add(playerControl.Data.PlayerName);
         }
-		return baseDesc;
+		return $"{base.GetFullDescription()}\n{Tr.GetString("curSharer")}:{string.Join(",", player)}";
 	}
 
     public override string GetIntroDescription()

--- a/ExtremeRoles/Roles/Combination/Traitor.cs
+++ b/ExtremeRoles/Roles/Combination/Traitor.cs
@@ -323,15 +323,23 @@ public sealed class Traitor : MultiAssignRoleBase, IRoleAutoBuildAbility, IRoleU
 
         byte rolePlayerId = byte.MaxValue;
 
-        foreach (var (playerId, role) in ExtremeRoleManager.GameRole)
+        foreach (PlayerControl playerControl in PlayerControl.AllPlayerControls)
         {
-            if (this.GameControlId == role.GameControlId)
+            if (playerControl == null ||
+				playerControl.Data == null ||
+                !ExtremeRoleManager.TryGetRole(playerControl.PlayerId, out var role) ||
+				this.GameControlId != role.GameControlId)
             {
-                rolePlayerId = playerId;
-                break;
+                continue;
             }
-        }
-        if (rolePlayerId == byte.MaxValue) { return; }
+
+			rolePlayerId = playerControl.PlayerId;
+			break;
+		}
+        if (rolePlayerId == byte.MaxValue)
+		{
+			return;
+		}
 
         if (PlayerControl.LocalPlayer.PlayerId == rolePlayerId)
         {


### PR DESCRIPTION
I've completed refactoring for files under ExtremeRoles/Roles/Combination to enhance safe role access.

This commit includes the following changes:
- Replaced direct `ExtremeRoleManager.GameRole[key]` access with `ExtremeRoleManager.TryGetRole(key, out var role)` in applicable files.
- Changed iterations over `ExtremeRoleManager.GameRole` to iterate over `PlayerControl.AllPlayerControls` and then use `TryGetRole` for safer access.
- Expanded one-liner if statements resulting from these changes into multi-line if statements for improved readability, based on your feedback.

Files modified in this phase:
- Mover.cs: (No direct GameRole[key] usage, but improved readability of a TryGetSafeCastedRole call)
- Sharer.cs: Refactored iterations.
- Supporter.cs: Refactored direct access and iterations, added error handling.
- Traitor.cs: Refactored iterations.

Files previously refactored or confirmed not needing changes:
- Accelerator.cs
- Avalon.cs
- Buddy.cs
- DetectiveOffice.cs
- Guesser.cs
- HeroAcademia.cs
- Kids.cs
- Lover.cs
- Skater.cs

This work addresses the issue of unsafe dictionary access and improves code robustness and readability.