### PR TITLE
Refactor: RoleAssignValidatorにアーリーリターンを適用

### DIFF
--- a/ExtremeRoles/Module/RoleAssign/RoleAssignValidator.cs
+++ b/ExtremeRoles/Module/RoleAssign/RoleAssignValidator.cs
@@ -19,24 +19,123 @@ public class RoleAssignValidator(IServiceProvider provider) : IRoleAssignValidat
 	public bool IsReBuild(in PreparationData prepareData)
 	{
 		Logging.Debug("------ RoleAssignValidator.IsReBuild START ------");
+		bool isUpdate = false;
 
 		if (!this.checkers.Any())
 		{
-			Logging.Debug("No checker defined. Skipping validation.");
-			Logging.Debug("--- RoleAssignValidator.IsReBuild END (No checker) ---");
+			Logging.Debug("No checkers registered. Skipping validation.");
+			Logging.Debug("------ RoleAssignValidator.IsReBuild END (No checkers) ------");
 			return false;
 		}
 
-		bool isUpdate = false;
 		foreach (var checker in this.checkers)
 		{
-			foreach (var ng in checker.GetNgData(prepareData))
+			Logging.Debug($"Running checker: {checker.GetType().Name}");
+			var ngRoleIds = checker.GetNgData(prepareData);
+
+			if (ngRoleIds == null || !ngRoleIds.Any())
 			{
-				// NGになったデータを元にprepareのデータを更新
-				isUpdate = true;
+				Logging.Debug($"No NG data found by {checker.GetType().Name}.");
+				continue;
+			}
+
+			Logging.Info($"NG data found by {checker.GetType().Name}. IDs: {string.Join(", ", ngRoleIds.Select(id => id.ToString()))}");
+			foreach (var ngRoleIdEnum in ngRoleIds) // ngRoleIdEnum is ExtremeRoleId
+			{
+				if (ProcessNgRole(ngRoleIdEnum, prepareData))
+				{
+					isUpdate = true; // If any role processing leads to an update, the overall method result is an update.
+				}
 			}
 		}
 
+		Logging.Debug($"------ RoleAssignValidator.IsReBuild END (isUpdate: {isUpdate}) ------");
 		return isUpdate;
+	}
+
+	private bool ProcessNgRole(ExtremeRoleId ngRoleIdEnum, PreparationData prepareData)
+	{
+		bool dataUpdatedInThisCall = false;
+		int ngRoleId = (int)ngRoleIdEnum;
+		Logging.Debug($"Processing NG RoleId: {ngRoleIdEnum}");
+
+		var assignmentsSnapshot = prepareData.Assign.Data.ToList();
+		foreach (var assignment in assignmentsSnapshot)
+		{
+			byte playerId = 0;
+			int roleId = -1;
+
+			if (assignment is PlayerToSingleRoleAssignData singleRoleAssignment)
+			{
+				playerId = singleRoleAssignment.PlayerId;
+				roleId = singleRoleAssignment.RoleId;
+			}
+			else if (assignment is PlayerToCombRoleAssignData combRoleAssignment)
+			{
+				playerId = combRoleAssignment.PlayerId;
+				roleId = combRoleAssignment.RoleId;
+			}
+			else // Should not happen if types are controlled, but good for robustness
+			{
+				continue;
+			}
+
+			if (roleId != ngRoleId)
+			{
+				continue;
+			}
+
+			Logging.Info($"Player {playerId} has NG RoleId: {ngRoleIdEnum}. Attempting to remove.");
+			bool removed = prepareData.Assign.RemoveAssignment(playerId, ngRoleId);
+
+			if (!removed)
+			{
+				Logging.Warning($"Failed to remove NG RoleId: {ngRoleIdEnum} from Player {playerId}. It might have been removed by another process or rule.");
+				continue; // Skip to next assignment if removal failed
+			}
+
+			dataUpdatedInThisCall = true; // Mark that data was updated
+			Logging.Info($"Successfully removed NG RoleId: {ngRoleIdEnum} from Player {playerId}.");
+
+			PlayerControl? playerControlToRequeue = PlayerCache.AllPlayerControl.FirstOrDefault(pc => pc.PlayerId == playerId);
+			if (playerControlToRequeue != null)
+			{
+				prepareData.Assign.AddPlayerToReassign(playerControlToRequeue);
+				Logging.Debug($"PlayerId: {playerId} added back to re-assign queue.");
+			}
+
+			ExtremeRoleType teamToAdjust = ExtremeRoleType.Null;
+			bool teamFound = false;
+
+			if (ExtremeRoleManager.NormalRole.TryGetValue(ngRoleId, out var roleDefinition))
+			{
+				teamToAdjust = roleDefinition.Team;
+				teamFound = true;
+			}
+			else
+			{
+				foreach (var combManager in ExtremeRoleManager.CombRole.Values)
+				{
+					var foundCombRolePart = combManager.Roles.FirstOrDefault(r => r.Id == ngRoleIdEnum);
+					if (foundCombRolePart != null)
+					{
+						teamToAdjust = foundCombRolePart.Team;
+						teamFound = true;
+						break;
+					}
+				}
+			}
+
+			if (teamFound && teamToAdjust != ExtremeRoleType.Null)
+			{
+				prepareData.Limit.Reduce(teamToAdjust, -1);
+				Logging.Info($"Spawn limit for Team: {teamToAdjust} increased by 1 due to removal of RoleId: {ngRoleIdEnum}.");
+			}
+			else
+			{
+				Logging.Warning($"Could not determine team for NG RoleId: {ngRoleIdEnum}. Spawn limit not adjusted.");
+			}
+		}
+		return dataUpdatedInThisCall;
 	}
 }


### PR DESCRIPTION
RoleAssignValidator.cs の IsReBuild メソッドおよび ProcessNgRole メソッドにアーリーリターンを積極的に活用し、ネストをさらに浅くしました。

- 条件チェック後に早期にリターンまたはコンティニューするように変更しました。
- これにより、elseブロックや不要なインデントが削減され、可読性がさらに向上しました。

## issueへのリンク
<!-- このPull requestによって修正される不具合または追加機能について議論されているissueの番号を＃をつけて記載、ない場合は修正される不具合または追加機能についてのissueを作成した上でPull requestをお願いします 例:#7 -->

## レビュワーに確認してほしいこと
<!-- このコードを見る全ての人(主にyukieiji)に対して確認してほしい事 -->

## チェックリスト
<!-- 以下のチェックリストはほぼマストです。確認をお願いします -->
- [] : ホストで追加する機能や役職、能力が使えることを確認した
- [] : ホスト以外で追加する機能や役職、能力が使えることを確認した
- [] : 役職の能力に関して会議が挟まる、サイドキックにされる等で正しくリセットされることを確認した

### 追加チェックリスト
<!-- これはコードの品質を保つためのチェックリストです、やってなくても構いません -->
- [] : 変数名に代入される値は妥当であるか
- [] : メソッド、関数名に相応しくない処理をしていないか
- [] : メソッド、関数は長くなりすぎてないか
- [] : 機能や役職の変数、メソッドのアクセシビリティレベルは妥当であるか(publicを多用していないか)
- [] : 機能や役職のデータ構造は妥当だと思われるものを使用しているか
