### PR TITLE
feat(ui): HD画面に対応するようにRoleInfoTextの位置とサイズを調整

### DIFF
--- a/ExtremeRoles/GameMode/IntroRunner/IIntroRunner.cs
+++ b/ExtremeRoles/GameMode/IntroRunner/IIntroRunner.cs
@@ -153,10 +153,32 @@ public interface IIntroRunner
 		var text = Object.Instantiate(
 			hudManager.TaskPanel.taskText,
 			hudManager.transform.parent);
-		text.transform.localPosition = new Vector3(-2.5f, 0.0f, -910f);
+
+		// Calculate the target world-space x-coordinate based on the camera's view.
+		var worldX = -Camera.main.orthographicSize * Camera.main.aspect + 2.0f;
+
+		// The y-coordinate should be 0 in world-space to be vertically centered.
+		// The z-coordinate's reference is unclear, but we'll calculate based on the parent.
+		var parentTransform = hudManager.transform.parent;
+		var worldPosition = new Vector3(worldX, 0.0f, parentTransform.position.z);
+
+		// Convert the world position to the parent's local space to ensure correct placement
+		// regardless of the parent's own transform.
+		var localPosition = parentTransform.InverseTransformPoint(worldPosition);
+
+		// The original code used a hardcoded local z-position of -910. We preserve this value
+		// as it's likely important for UI layering.
+		localPosition.z = -910f;
+
+		text.transform.localPosition = localPosition;
+
 		text.fontSizeMin = text.fontSizeMax = text.fontSize = 1.75f;
 		text.alignment = TextAlignmentOptions.MidlineLeft;
-		text.rectTransform.sizeDelta = new Vector2(20.0f, 20.0f);
+		// Dynamically calculate the width to be the screen width minus margins.
+		float width = (Camera.main.orthographicSize * Camera.main.aspect * 2) - 4.0f;
+		// Set height to a generous value to accommodate multiple lines of team info.
+		float height = 10.0f;
+		text.rectTransform.sizeDelta = new Vector2(width, height);
 		text.gameObject.layer = 5;
 
 		return text;


### PR DESCRIPTION
HD画面でもRoleInfoTextが画面内に収まるように、以下の変更を行いました。

- TextのX座標を、親のTransformに影響されないようカメラのWorld座標基準で動的に計算するように変更
- TextのRectTransformのsizeDeltaを、画面幅に合わせて動的に計算するように変更し、テキストが常に画面内に収まるようにした

## issueへのリンク
<!-- このPull requestによって修正される不具合または追加機能について議論されているissueの番号を＃をつけて記載、ない場合は修正される不具合または追加機能についてのissueを作成した上でPull requestをお願いします 例:#7 -->

## レビュワーに確認してほしいこと
<!-- このコードを見る全ての人(主にyukieiji)に対して確認してほしい事 -->

## チェックリスト
<!-- 以下のチェックリストはほぼマストです。確認をお願いします -->
- [] : ホストで追加する機能や役職、能力が使えることを確認した
- [] : ホスト以外で追加する機能や役職、能力が使えることを確認した
- [] : 役職の能力に関して会議が挟まる、サイドキックにされる等で正しくリセットされることを確認した

### 追加チェックリスト
<!-- これはコードの品質を保つためのチェックリストです、やってなくても構いません -->
- [] : 変数名に代入される値は妥当であるか
- [] : メソッド、関数名に相応しくない処理をしていないか
- [] : メソッド、関数は長くなりすぎてないか
- [] : 機能や役職の変数、メソッドのアクセシビリティレベルは妥当であるか(publicを多用していないか)
- [] : 機能や役職のデータ構造は妥当だと思われるものを使用しているか
