### PR TITLE
Refactor(Vote): Overhaul vote animation logic with a multi-phase design

### DIFF
--- a/ExtremeRoles/Module/Meeting/VoteCollection.cs
+++ b/ExtremeRoles/Module/Meeting/VoteCollection.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace ExtremeRoles.Module.Meeting
+{
+    public sealed class VoteCollection
+    {
+        private readonly List<VoteModification> _votes = new List<VoteModification>();
+
+        public void Add(VoteModification vote)
+        {
+            _votes.Add(vote);
+        }
+
+        public void AddRange(IEnumerable<VoteModification> votes)
+        {
+            _votes.AddRange(votes);
+        }
+
+        public IReadOnlyList<VoteModification> GetAllVotes()
+        {
+            return _votes;
+        }
+
+    }
+}

--- a/ExtremeRoles/Module/Meeting/VoteModification.cs
+++ b/ExtremeRoles/Module/Meeting/VoteModification.cs
@@ -1,0 +1,16 @@
+namespace ExtremeRoles.Module.Meeting
+{
+    public readonly struct VoteModification
+    {
+        public VoteModification(byte voterId, byte targetId, int voteCount)
+        {
+            VoterId = voterId;
+            TargetId = targetId;
+            VoteCount = voteCount;
+        }
+
+        public byte VoterId { get; }
+        public byte TargetId { get; }
+        public int VoteCount { get; }
+    }
+}

--- a/ExtremeRoles/Patches/Meeting/Hud/PopulateResultsPatch.cs
+++ b/ExtremeRoles/Patches/Meeting/Hud/PopulateResultsPatch.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using UnityEngine;
 
 using HarmonyLib;
@@ -10,6 +10,8 @@ using ExtremeRoles.Module.Event;
 using ExtremeRoles.Module.RoleAssign;
 using ExtremeRoles.Roles;
 using ExtremeRoles.Roles.API.Interface;
+using ExtremeRoles.Module.Meeting;
+using ExtremeRoles.Performance.Il2Cpp;
 
 namespace ExtremeRoles.Patches.Meeting.Hud;
 
@@ -22,7 +24,6 @@ public static class MeetingHudPopulateResultsPatch
 		MeetingHud __instance,
 		[HarmonyArgument(0)] Il2CppStructArray<MeetingHud.VoterState> states)
 	{
-
 		if (!RoleAssignState.Instance.IsRoleSetUpEnd)
 		{
 			return true;
@@ -34,81 +35,112 @@ public static class MeetingHudPopulateResultsPatch
 			TranslationController.Instance.GetString(
 				StringNames.MeetingVotingResults, Array.Empty<Il2CppSystem.Object>());
 
-		Dictionary<byte, int> voteIndex = new Dictionary<byte, int>();
-		SortedList<int, (IRoleVoteModifier, NetworkedPlayerInfo)> voteModifier = new SortedList<
-			int, (IRoleVoteModifier, NetworkedPlayerInfo)>();
+		// --- Phase 1: Data Gathering and Caching ---
 
-		var allVoteHook = new List<(IRoleHookVoteEnd, NetworkedPlayerInfo)>();
+		var allVotes = new VoteCollection();
+		var voteModifierRoles = new SortedList<int, (IRoleVoteModifier, NetworkedPlayerInfo)>();
+		var voteHookRoles = new List<(IRoleHookVoteEnd, NetworkedPlayerInfo)>();
 
-		int num = 0;
-		// それぞれの人に対してどんな投票があったか
+		var playerAreaMap = new Dictionary<byte, PlayerVoteArea>();
+		var playerInfoMap = GameData.Instance.AllPlayers.GetFastEnumerator().ToDictionary(p => p.PlayerId);
+
 		for (int i = 0; i < __instance.playerStates.Length; i++)
 		{
 			PlayerVoteArea playerVoteArea = __instance.playerStates[i];
 			playerVoteArea.ClearForResults();
 
 			byte checkPlayerId = playerVoteArea.TargetPlayerId;
-
-			// 切断されたプレイヤーは残っている状態で役職を持たない状態になるのでキーチェックはしておく
-			if (ExtremeRoleManager.GameRole.ContainsKey(checkPlayerId))
+			if (checkPlayerId >= 0)
 			{
-				// 投票をいじる役職か？
-				var (voteModRole, voteAnotherRole) =
-					ExtremeRoleManager.GetInterfaceCastedRole<IRoleVoteModifier>(checkPlayerId);
-				addVoteModRole(voteModRole, checkPlayerId, ref voteModifier);
-				addVoteModRole(voteAnotherRole, checkPlayerId, ref voteModifier);
-
-				//　投票時のHook処理
-				var (voteHook, voteHookAnotherRole) =
-					ExtremeRoleManager.GetInterfaceCastedRole<IRoleHookVoteEnd>(checkPlayerId);
-				addVoteHookRole(voteHook, checkPlayerId, allVoteHook);
-				addVoteHookRole(voteHookAnotherRole, checkPlayerId, allVoteHook);
+				playerAreaMap[checkPlayerId] = playerVoteArea;
 			}
 
-			int noneSkipVote = 0;
-			foreach (MeetingHud.VoterState voterState in states)
+			if (ExtremeRoleManager.GameRole.ContainsKey(checkPlayerId) && playerInfoMap.TryGetValue(checkPlayerId, out var playerInfo))
 			{
-				NetworkedPlayerInfo playerById = GameData.Instance.GetPlayerById(voterState.VoterId);
-				if (playerById == null)
+				var (voteModRole, voteAnotherRole) = ExtremeRoleManager.GetInterfaceCastedRole<IRoleVoteModifier>(checkPlayerId);
+				addVoteModRole(voteModRole, playerInfo, ref voteModifierRoles);
+				addVoteModRole(voteAnotherRole, playerInfo, ref voteModifierRoles);
+
+				var (voteHook, voteHookAnotherRole) = ExtremeRoleManager.GetInterfaceCastedRole<IRoleHookVoteEnd>(checkPlayerId);
+				addVoteHookRole(voteHook, playerInfo, voteHookRoles);
+				addVoteHookRole(voteHookAnotherRole, playerInfo, voteHookRoles);
+			}
+
+			foreach (var voterState in states)
+			{
+				if (i == 0 && voterState.SkippedVote)
 				{
-					Debug.LogError(
-						string.Format("Couldn't find player info for voter: {0}",
-						voterState.VoterId));
-				}
-				else if (i == 0 && voterState.SkippedVote)
-				{
-					// スキップのアニメーション
-					__instance.BloopAVoteIcon(playerById, num, __instance.SkippedVoting.transform);
-					num++;
+					allVotes.Add(new VoteModification(voterState.VoterId, 255, 1));
 				}
 				else if (voterState.VotedForId == checkPlayerId)
 				{
-					// 投票された人のアニメーション
-					__instance.BloopAVoteIcon(playerById, noneSkipVote, playerVoteArea.transform);
-					noneSkipVote++;
+					allVotes.Add(new VoteModification(voterState.VoterId, checkPlayerId, 1));
 				}
 			}
-			voteIndex.Add(playerVoteArea.TargetPlayerId, noneSkipVote);
 		}
 
-		voteIndex[__instance.playerStates[0].TargetPlayerId] = num;
+		// --- Phase 2: Vote Modification ---
 
-		foreach (var (role, player) in voteModifier.Values)
+		foreach (var (role, player) in voteModifierRoles.Values)
 		{
-			role.ModifiedVoteAnime(
-				__instance, player, ref voteIndex);
+			allVotes.AddRange(role.GetVoteModifications(player));
 			role.ResetModifier();
 		}
 
-		foreach (var (role, player) in allVoteHook)
+		// --- Phase 3: Animation and Final Count Calculation ---
+
+		var finalVoteCounts = new Dictionary<byte, int>();
+		var skipVoteTargetId = __instance.playerStates[0].TargetPlayerId;
+
+		foreach (var vote in allVotes.GetAllVotes())
 		{
-			role.HookVoteEnd(__instance, player, voteIndex);
+			AnimateVote(__instance, vote, finalVoteCounts, playerAreaMap, playerInfoMap, skipVoteTargetId);
+		}
+
+		// --- Final Hook Call ---
+
+		foreach (var (role, player) in voteHookRoles)
+		{
+			role.HookVoteEnd(__instance, player, finalVoteCounts);
 		}
 
 		return false;
 	}
+
+	private static void AnimateVote(MeetingHud instance, VoteModification vote, Dictionary<byte, int> voteIndex, IReadOnlyDictionary<byte, PlayerVoteArea> playerAreaMap, IReadOnlyDictionary<byte, NetworkedPlayerInfo> playerInfoMap, byte skipVoteTargetId)
+	{
+		if (!playerInfoMap.TryGetValue(vote.VoterId, out var voterInfo))
+		{
+			Debug.LogError($"Couldn't find player info for voter: {vote.VoterId}");
+			return;
+		}
+
+		Transform targetTransform;
+		byte effectiveTargetId = vote.TargetId;
+
+		if (playerAreaMap.TryGetValue(vote.TargetId, out var targetArea))
+		{
+			targetTransform = targetArea.transform;
+		}
+		else
+		{
+			targetTransform = instance.SkippedVoting.transform;
+			effectiveTargetId = skipVoteTargetId;
+		}
+
+		for (int i = 0; i < vote.VoteCount; i++)
+		{
+			if (!voteIndex.TryGetValue(effectiveTargetId, out int currentVoteCount))
+			{
+				currentVoteCount = 0;
+			}
+			instance.BloopAVoteIcon(voterInfo, currentVoteCount, targetTransform);
+			voteIndex[effectiveTargetId] = currentVoteCount + 1;
+		}
+	}
+
 	private static void addVoteModRole(
-		IRoleVoteModifier? role, byte rolePlayerId,
+		IRoleVoteModifier? role, NetworkedPlayerInfo playerInfo,
 		ref SortedList<int, (IRoleVoteModifier, NetworkedPlayerInfo)> voteModifier)
 	{
 		if (role is null)
@@ -116,19 +148,16 @@ public static class MeetingHudPopulateResultsPatch
 			return;
 		}
 
-		NetworkedPlayerInfo playerById = GameData.Instance.GetPlayerById(rolePlayerId);
-
 		int order = role.Order;
-		// 同じ役職は同じ優先度になるので次の優先度になるようにセット
 		while (voteModifier.ContainsKey(order))
 		{
 			++order;
 		}
-		voteModifier.Add(order, (role, playerById));
+		voteModifier.Add(order, (role, playerInfo));
 	}
 
 	private static void addVoteHookRole(
-		IRoleHookVoteEnd? role, byte rolePlayerId,
+		IRoleHookVoteEnd? role, NetworkedPlayerInfo playerInfo,
 		in List<(IRoleHookVoteEnd, NetworkedPlayerInfo)> voteHook)
 	{
 		if (role is null)
@@ -136,7 +165,6 @@ public static class MeetingHudPopulateResultsPatch
 			return;
 		}
 
-		NetworkedPlayerInfo playerById = GameData.Instance.GetPlayerById(rolePlayerId);
-		voteHook.Add((role, playerById));
+		voteHook.Add((role, playerInfo));
 	}
 }

--- a/ExtremeRoles/Roles/API/Interface/IRoleVoteModifier.cs
+++ b/ExtremeRoles/Roles/API/Interface/IRoleVoteModifier.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using ExtremeRoles.Module.Meeting;
 
 namespace ExtremeRoles.Roles.API.Interface;
 
@@ -20,10 +21,8 @@ public interface IRoleVoteModifier
         ref Dictionary<byte, byte> voteTarget,
         ref Dictionary<byte, int> voteResult);
 
-    public void ModifiedVoteAnime(
-        MeetingHud instance,
-        NetworkedPlayerInfo rolePlayer,
-        ref Dictionary<byte, int> voteIndex);
+    public IEnumerable<VoteModification> GetVoteModifications(
+        NetworkedPlayerInfo rolePlayer);
         
     public void ResetModifier();
 }

--- a/ExtremeRoles/Roles/Solo/Crewmate/Captain.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/Captain.cs
@@ -82,11 +82,17 @@ public sealed class Captain :
         {
             case AbilityType.SetVoteTarget:
                 byte targetPlayerId = reader.ReadByte();
-                if (captain == null) { return; }
+                if (captain == null)
+                {
+                    return;
+                }
                 captain.SetTargetVote(targetPlayerId);
                 break;
             case AbilityType.ChargeVote:
-                if (captain == null) { return; }
+                if (captain == null)
+                {
+                    return;
+                }
                 captain.ChargeVote();
                 break;
             default:
@@ -145,27 +151,16 @@ public sealed class Captain :
             }
         }
     }
-    public void ModifiedVoteAnime(
-        MeetingHud instance,
-        NetworkedPlayerInfo rolePlayer,
-        ref Dictionary<byte, int> voteIndex)
+    public IEnumerable<VoteModification> GetVoteModifications(NetworkedPlayerInfo rolePlayer)
     {
-        PlayerVoteArea pva = instance.playerStates.FirstOrDefault(
-            x => x.TargetPlayerId == this.voteTarget);
-
-        if (pva == null) { return; }
-
-        if (!voteIndex.TryGetValue(pva.TargetPlayerId, out int startIndex))
+        if (this.voteTarget != byte.MaxValue)
         {
-            startIndex = 0;
+            int addVoteNum = (int)Math.Floor(this.curChargedVote);
+            if (addVoteNum > 0)
+            {
+                yield return new VoteModification(rolePlayer.PlayerId, this.voteTarget, addVoteNum);
+            }
         }
-
-        int addVoteNum = (int)Math.Floor(this.curChargedVote);
-        for (int i = 0; i < addVoteNum; ++i)
-        {
-            instance.BloopAVoteIcon(rolePlayer, startIndex + i, pva.transform);
-        }
-        voteIndex[pva.TargetPlayerId] = startIndex + addVoteNum;
     }
 
     public void ResetModifier()


### PR DESCRIPTION
Completely refactors the `MeetingHudPopulateResultsPatch` to follow a clean, multi-phase architecture and a new `VoteCollection` class, as per user design.

- Preserves original animation order by using a nested loop for initial data gathering.
- Decouples role logic from UI animation by using `VoteCollection` and `VoteModification` data structures.
- Centralizes all animation logic in a single, simplified helper method.
- Unifies the vote counting logic for both animation and hooks, removing redundant calculations.
- Improves performance by caching player info and UI components.
- Updates `Gambler` and `Captain` roles to conform to the new interface.
- Fixes single-line `if` statements to improve code style.
