### PR TITLE
Fix : MultiAssignRoleBaseでAnotherRoleがある場合のAnotherRoleの能力発動チェック時、MultiAssignRoleBaseの判定チェックが抜けていた問題の修正

### DIFF
--- a/ExtremeRoles/GhostRoles/Neutral/Foras.cs
+++ b/ExtremeRoles/GhostRoles/Neutral/Foras.cs
@@ -188,10 +188,7 @@ public sealed class Foras : GhostRoleBase
     {
         if (!GameProgressSystem.IsTaskPhase) { return false; }
 
-        this.targetPlayer = Helper.Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer,
-            ExtremeRoleManager.GetLocalPlayerRole(),
-            this.range);
+        this.targetPlayer = Helper.Player.GetClosestPlayerInRange(this.range);
 
         return IsCommonUse() && this.targetPlayer != null;
     }

--- a/ExtremeRoles/Helper/Player.cs
+++ b/ExtremeRoles/Helper/Player.cs
@@ -129,6 +129,17 @@ public static class Player
         return playersInAbilityRangeSorted[0];
     }
 
+	public static PlayerControl GetClosestPlayerInRange(float range)
+	{
+		var localPlayer = PlayerControl.LocalPlayer;
+		if (localPlayer == null)
+		{
+			return null; 
+		}
+
+		var role = ExtremeRoleManager.GetLocalPlayerRole();
+		return GetClosestPlayerInRange(PlayerControl.LocalPlayer, role, range);
+	}
 
 	public static PlayerControl GetClosestPlayerInRange(
         PlayerControl sourcePlayer,

--- a/ExtremeRoles/Helper/Player.cs
+++ b/ExtremeRoles/Helper/Player.cs
@@ -138,7 +138,7 @@ public static class Player
 		}
 
 		var role = ExtremeRoleManager.GetLocalPlayerRole();
-		return GetClosestPlayerInRange(PlayerControl.LocalPlayer, role, range);
+		return GetClosestPlayerInRange(localPlayer, role, range);
 	}
 
 	public static PlayerControl GetClosestPlayerInRange(

--- a/ExtremeRoles/Roles/Combination/HeroAcademia/HeroAcademia.cs
+++ b/ExtremeRoles/Roles/Combination/HeroAcademia/HeroAcademia.cs
@@ -901,8 +901,7 @@ public sealed class Vigilante : MultiAssignRoleBase, IRoleAutoBuildAbility, IRol
     {
         target = byte.MaxValue;
 
-        PlayerControl player = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this, range);
+        PlayerControl player = Player.GetClosestPlayerInRange(this.range);
 
         if (player == null) { return false; }
         target = player.PlayerId;

--- a/ExtremeRoles/Roles/Combination/Kids.cs
+++ b/ExtremeRoles/Roles/Combination/Kids.cs
@@ -312,8 +312,7 @@ public sealed class Delinquent : MultiAssignRoleBase, IRoleAutoBuildAbility
             AbilityType.Scribe =>
                 IRoleAbility.IsCommonUse(),
             AbilityType.SelfBomb =>
-                Player.GetClosestPlayerInRange(
-                    PlayerControl.LocalPlayer, this, this.range) != null,
+                Player.GetClosestPlayerInRange(this.range) != null,
             _ => true
         };
     }

--- a/ExtremeRoles/Roles/Solo/Crewmate/Agency.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/Agency.cs
@@ -184,9 +184,7 @@ public sealed class Agency : SingleRoleBase, IRoleAutoBuildAbility, IRoleUpdate
 
         this.TargetPlayer = byte.MaxValue;
 
-        PlayerControl target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-            this.takeTaskRange);
+        PlayerControl target = Player.GetClosestPlayerInRange(this.takeTaskRange);
 
         if (target != null)
         {

--- a/ExtremeRoles/Roles/Solo/Crewmate/BodyGuard.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/BodyGuard.cs
@@ -576,9 +576,7 @@ public sealed class BodyGuard :
     {
         this.targetPlayer = byte.MaxValue;
 
-        PlayerControl target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-            this.shieldRange);
+        PlayerControl target = Player.GetClosestPlayerInRange(this.shieldRange);
 
 		if (target != null)
 		{

--- a/ExtremeRoles/Roles/Solo/Crewmate/Delusioner/DelusionerRole.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/Delusioner/DelusionerRole.cs
@@ -128,10 +128,11 @@ public sealed class DelusionerRole :
 
         targetPlayerId = byte.MaxValue;
 
-        PlayerControl target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-            this.status.Range);
-        if (target == null) { return false; }
+        PlayerControl target = Player.GetClosestPlayerInRange(this.status.Range);
+        if (target == null)
+		{
+			return false;
+		}
 
         targetPlayerId = target.PlayerId;
 

--- a/ExtremeRoles/Roles/Solo/Crewmate/Jailer.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/Jailer.cs
@@ -156,10 +156,11 @@ public sealed class Jailer : SingleRoleBase, IRoleAutoBuildAbility, IRoleAwake<R
 	{
 		this.targetPlayerId = byte.MaxValue;
 
-		PlayerControl target = Player.GetClosestPlayerInRange(
-			PlayerControl.LocalPlayer, this,
-			this.range);
-		if (target == null) { return false; }
+		PlayerControl target = Player.GetClosestPlayerInRange(this.range);
+		if (target == null)
+		{
+			return false;
+		}
 
 		this.targetPlayerId = target.PlayerId;
 

--- a/ExtremeRoles/Roles/Solo/Crewmate/Summoner.cs
+++ b/ExtremeRoles/Roles/Solo/Crewmate/Summoner.cs
@@ -188,9 +188,7 @@ public sealed class Summoner :
 	{
 		this.targetData = null;
 
-		PlayerControl target = Player.GetClosestPlayerInRange(
-			PlayerControl.LocalPlayer, this,
-			this.range);
+		PlayerControl target = Player.GetClosestPlayerInRange(this.range);
 		if (target == null ||
 			(
 				this.summonTarget != null &&

--- a/ExtremeRoles/Roles/Solo/Impostor/Boxer.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Boxer.cs
@@ -75,7 +75,7 @@ public sealed class Boxer : SingleRoleBase, IRoleAutoBuildAbility
 
     public bool IsAbilityUse()
     {
-		this.target = Player.GetClosestPlayerInRange(PlayerControl.LocalPlayer, this, this.range);
+		this.target = Player.GetClosestPlayerInRange(this.range);
         return IRoleAbility.IsCommonUse() && this.target != null;
     }
 

--- a/ExtremeRoles/Roles/Solo/Impostor/Hypnotist.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Hypnotist.cs
@@ -316,9 +316,7 @@ public sealed class Hypnotist :
 			return false;
 		}
 
-        this.target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer,
-            this, this.range);
+        this.target = Player.GetClosestPlayerInRange(this.range);
 
         return this.target != null && IRoleAbility.IsCommonUse();
     }

--- a/ExtremeRoles/Roles/Solo/Impostor/SandWorm.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/SandWorm.cs
@@ -167,9 +167,7 @@ public sealed class SandWorm : SingleRoleBase, IRoleAbility, ITryKillTo
 
     public bool IsAbilityUse()
     {
-        this.targetPlayer = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer,
-            this, this.range);
+        this.targetPlayer = Player.GetClosestPlayerInRange(this.range);
 
         return isVentIn() && this.targetPlayer != null;
     }

--- a/ExtremeRoles/Roles/Solo/Impostor/SlaveDriver.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/SlaveDriver.cs
@@ -169,8 +169,7 @@ public sealed class SlaveDriver :
 
 	public bool IsAbilityUse()
 	{
-		var target = Player.GetClosestPlayerInRange(
-			PlayerControl.LocalPlayer, this, this.range);
+		var target = Player.GetClosestPlayerInRange(this.range);
 
 		if (target == null) { return false; }
 

--- a/ExtremeRoles/Roles/Solo/Neutral/Eater.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Eater.cs
@@ -127,8 +127,7 @@ public sealed class Eater : SingleRoleBase, IRoleAutoBuildAbility, IRoleMurderPl
         if (this.Button == null ||
             this.modeFactory == null) { return false; }
 
-        this.tmpTarget = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this, this.range);
+        this.tmpTarget = Player.GetClosestPlayerInRange(this.range);
 
         this.targetDeadBody = Player.GetDeadBodyInfo(
             this.range);

--- a/ExtremeRoles/Roles/Solo/Neutral/Heretic.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Heretic.cs
@@ -136,8 +136,7 @@ public sealed class Heretic :
 			return false;
 		}
 
-		var player = Player.GetClosestPlayerInRange(
-		   PlayerControl.LocalPlayer, this, this.range);
+		var player = Player.GetClosestPlayerInRange(this.range);
 
 		if (player == null ||
 			this.meetingTarget == player.PlayerId)

--- a/ExtremeRoles/Roles/Solo/Neutral/Jackal/JackalRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Jackal/JackalRole.cs
@@ -320,9 +320,7 @@ public sealed class JackalRole : SingleRoleBase, IRoleAutoBuildAbility, IRoleSpe
 		}
 
 
-        Target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer,
-            this, range[Mathf.Clamp(createSidekickRange, 0, 2)]);
+        Target = Player.GetClosestPlayerInRange(range[Mathf.Clamp(createSidekickRange, 0, 2)]);
 
         return Target != null && IRoleAbility.IsCommonUse();
     }

--- a/ExtremeRoles/Roles/Solo/Neutral/Jester.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Jester.cs
@@ -81,9 +81,7 @@ public sealed class Jester : SingleRoleBase, IRoleAutoBuildAbility
 
     public bool IsAbilityUse()
     {
-        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-            this.outburstDistance);
+        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(this.outburstDistance);
         return IRoleAbility.IsCommonUse() && this.tmpTarget != null;
     }
 

--- a/ExtremeRoles/Roles/Solo/Neutral/Missionary/Missionary.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Missionary/Missionary.cs
@@ -149,9 +149,7 @@ public sealed class MissionaryRole :
 
     public bool IsAbilityUse()
     {
-		this.targetPlayer = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-			this.propagateRange);
+		this.targetPlayer = Player.GetClosestPlayerInRange(this.propagateRange);
 
 		if (this.targetPlayer == null)
 		{

--- a/ExtremeRoles/Roles/Solo/Neutral/Monika.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Monika.cs
@@ -61,9 +61,7 @@ public sealed class Monika :
 		}
 
 		this.targetPlayer = byte.MaxValue;
-		var player = Player.GetClosestPlayerInRange(
-			PlayerControl.LocalPlayer, this,
-			this.range);
+		var player = Player.GetClosestPlayerInRange(this.range);
 
 		if (player == null ||
 			this.trashSystem.InvalidPlayer(player))

--- a/ExtremeRoles/Roles/Solo/Neutral/Queen/QueenRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Queen/QueenRole.cs
@@ -332,9 +332,7 @@ public sealed class QueenRole :
 
     public bool IsAbilityUse()
     {
-        Target = Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer,
-            this, range);
+        Target = Player.GetClosestPlayerInRange(range);
 
         return Target != null && IRoleAbility.IsCommonUse();
     }

--- a/ExtremeRoles/Roles/Solo/Neutral/TotoCalcio.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/TotoCalcio.cs
@@ -79,9 +79,7 @@ public sealed class Totocalcio : SingleRoleBase, IRoleAutoBuildAbility, IRoleWin
 
     public bool IsAbilityUse()
     {
-        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this,
-            this.range);
+        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(this.range);
 
         if (this.tmpTarget == null ||
             this.tmpTarget.Data == null) { return false; }

--- a/ExtremeRoles/Roles/Solo/Neutral/Tucker/TuckerRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Tucker/TuckerRole.cs
@@ -364,9 +364,7 @@ public sealed class TuckerRole :
 	{
 		target = byte.MaxValue;
 
-		var targetPlayer = Player.GetClosestPlayerInRange(
-			PlayerControl.LocalPlayer,
-			this, range);
+		var targetPlayer = Player.GetClosestPlayerInRange(range);
 		if (targetPlayer == null)
 		{
 			return false;

--- a/ExtremeRoles/Roles/Solo/Neutral/Umbrer.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Umbrer.cs
@@ -239,8 +239,7 @@ public sealed class Umbrer : SingleRoleBase, IRoleAutoBuildAbility, IRoleSpecial
 
     public bool IsAbilityUse()
     {
-        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(
-            PlayerControl.LocalPlayer, this, this.range);
+        this.tmpTarget = Helper.Player.GetClosestPlayerInRange(this.range);
 
         bool isUpgrade = this.container.IsFirstStage(
             this.tmpTarget == null ? byte.MaxValue : this.tmpTarget.PlayerId);


### PR DESCRIPTION
MultiAssignRoleBaseでAnotherRoleがある場合のAnotherRoleの能力発動チェック時、MultiAssignRoleBaseの判定チェックが抜けていた問題の修正

多分現状だとサーヴァントくらいしか問題にならないけど、今後増える予定があるので毎チェック時に自分自身の役職を取ってくるように調整