### PR TITLE
Refactor(Neutral, Impostor): CreateSpecificOptionのAPIを新しいものに移行

### DIFF
--- a/ExtremeRoles/Roles/Solo/Impostor/AssaultMaster.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/AssaultMaster.cs
@@ -202,8 +202,9 @@ public sealed class AssaultMaster : SingleRoleBase, IRoleAutoBuildAbility, IRole
         base.GetFullDescription(), this.stock,
         this.stockMax, this.curReloadCoolTime);
 
-    protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateCommonAbilityOption(factory);
 
         factory.CreateIntOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Bomber.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Bomber.cs
@@ -100,9 +100,9 @@ public sealed class Bomber : SingleRoleBase, IRoleAutoBuildAbility, IRoleUpdate
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 2, 5, 2.5f);
         factory.CreateIntOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/BountyHunter.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/BountyHunter.cs
@@ -102,10 +102,9 @@ public sealed class BountyHunter : SingleRoleBase, IRoleUpdate, IRoleSpecialSetU
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
-
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             BountyHunterOption.TargetUpdateTime,
             60f, 30.0f, 120f, 0.5f,

--- a/ExtremeRoles/Roles/Solo/Impostor/Boxer.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Boxer.cs
@@ -178,9 +178,9 @@ public sealed class Boxer : SingleRoleBase, IRoleAutoBuildAbility
 		beha.Initialize(speed, role.speed, role.killSpeed, role.param);
 	}
 
-	protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(factory, 2, 5);
 		factory.CreateFloatOption(Option.StraightChargeTime, 3.0f, 0.1f, 30.0f, 0.1f, format: OptionUnit.Second);
 		factory.CreateFloatOption(Option.StraightRange, 1.2f, 0.1f, 3.0f, 0.1f);

--- a/ExtremeRoles/Roles/Solo/Impostor/Carrier.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Carrier.cs
@@ -203,9 +203,9 @@ public sealed class Carrier : SingleRoleBase, IRoleAutoBuildAbility, IRoleSpecia
             deadBodyToReportablePosition(this, player));
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateCommonAbilityOption(
             factory, 5.0f);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/Commander.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Commander.cs
@@ -125,9 +125,9 @@ public sealed class Commander : SingleRoleBase, IRoleAutoBuildAbility, ITryKillT
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             CommanderOption.KillCoolReduceTime,
             2.0f, 0.5f, 5.0f, 0.1f,

--- a/ExtremeRoles/Roles/Solo/Impostor/Cracker.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Cracker.cs
@@ -137,9 +137,9 @@ public sealed class Cracker : SingleRoleBase, IRoleAutoBuildAbility
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 2, 5);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/Crewshroom.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Crewshroom.cs
@@ -71,9 +71,9 @@ public sealed class Crewshroom : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
 	}
 
-	protected override void CreateSpecificOption(
-		AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(factory, 3, 50);
 		factory.CreateFloatOption(
 			Option.DelaySecond, 5.0f, 0.5f, 30.0f, 0.5f, format:OptionUnit.Second);

--- a/ExtremeRoles/Roles/Solo/Impostor/Evolver.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Evolver.cs
@@ -141,9 +141,9 @@ public sealed class Evolver : SingleRoleBase, IRoleAutoBuildAbility
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             EvolverOption.IsEvolvedAnimation,
             true);

--- a/ExtremeRoles/Roles/Solo/Impostor/Faker.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Faker.cs
@@ -120,9 +120,9 @@ public sealed class Faker : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
 	}
 
-	protected override void CreateSpecificOption(
-		AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateCommonAbilityOption(
 			factory);
 		factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Glitch.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Glitch.cs
@@ -140,9 +140,9 @@ public sealed class Glitch : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
 	}
 
-	protected override void CreateSpecificOption(
-		AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(
 			factory, 2, 10);
 		factory.CreateFloatOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Hijacker.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Hijacker.cs
@@ -131,9 +131,9 @@ public sealed class Hijacker : SingleRoleBase, IRoleAbility
 		return true;
 	}
 
-	protected override void CreateSpecificOption(
-		AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(
 			factory, 3, 10, 10f);
 		factory.CreateBoolOption(Option.IsRandomPlayer, true);

--- a/ExtremeRoles/Roles/Solo/Impostor/Hypnotist.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Hypnotist.cs
@@ -564,9 +564,9 @@ public sealed class Hypnotist :
         }
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             HypnotistOption.AwakeCheckImpostorNum,
             1, 1, GameSystem.MaxImposterNum, 1);

--- a/ExtremeRoles/Roles/Solo/Impostor/LastWolf.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/LastWolf.cs
@@ -260,9 +260,9 @@ public sealed class LastWolf : SingleRoleBase, IRoleAutoBuildAbility, IRoleAwake
     }
 
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             LastWolfOption.AwakeImpostorNum,
             1, 1, GameSystem.MaxImposterNum, 1);

--- a/ExtremeRoles/Roles/Solo/Impostor/Magician.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Magician.cs
@@ -125,8 +125,9 @@ public sealed class Magician : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
 	}
 
-    protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(factory, 1, 10);
 
         factory.CreateIntOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Mery.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Mery.cs
@@ -313,9 +313,9 @@ public sealed class Mery : SingleRoleBase, IRoleAutoBuildAbility
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 3, 5);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/OverLoader.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/OverLoader.cs
@@ -189,9 +189,9 @@ public sealed class OverLoader : SingleRoleBase, IRoleAutoBuildAbility, IRoleAwa
 			base.GetNameColor(isTruthColor) : Palette.ImpostorRed;
 
 
-	protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             OverLoaderOption.AwakeImpostorNum,
             GameSystem.MaxImposterNum, 1,

--- a/ExtremeRoles/Roles/Solo/Impostor/Painter.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Painter.cs
@@ -136,9 +136,9 @@ public sealed class Painter : SingleRoleBase, IRoleAutoBuildAbility
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateCommonAbilityOption(
             factory);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/PsychoKiller.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/PsychoKiller.cs
@@ -162,9 +162,9 @@ public sealed class PsychoKiller :
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             PsychoKillerOption.KillCoolReduceRate,
             5, 1, 15, 1,

--- a/ExtremeRoles/Roles/Solo/Impostor/Raider.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Raider.cs
@@ -284,9 +284,9 @@ public sealed class Raider : SingleRoleBase, IRoleAutoBuildAbility, IRoleUpdate
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 2, 10);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/SandWorm.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/SandWorm.cs
@@ -216,9 +216,9 @@ public sealed class SandWorm : SingleRoleBase, IRoleAbility, ITryKillTo
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             SandWormOption.KillCoolPenalty,
             5.0f, 1.0f, 10.0f, 0.1f,

--- a/ExtremeRoles/Roles/Solo/Impostor/Scavenger.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Scavenger.cs
@@ -1348,8 +1348,9 @@ public sealed class Scavenger : SingleRoleBase, IRoleUpdate, IRoleAbility
 	}
 
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateFloatOption(
 			RoleAbilityCommonOption.AbilityCoolTime,
 			IRoleAbility.DefaultCoolTime,

--- a/ExtremeRoles/Roles/Solo/Impostor/Shooter.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Shooter.cs
@@ -355,9 +355,9 @@ public sealed class Shooter :
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             ShooterOption.IsInitAwake,
             false);

--- a/ExtremeRoles/Roles/Solo/Impostor/SlaveDriver.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/SlaveDriver.cs
@@ -68,9 +68,9 @@ public sealed class SlaveDriver :
 		return base.GetRolePlayerNameTag(targetRole, targetPlayerId);
 	}
 
-	protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			SlaveDriverOption.CanSeeTaskBar,
 			true);

--- a/ExtremeRoles/Roles/Solo/Impostor/Slime.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Slime.cs
@@ -196,9 +196,9 @@ public sealed class Slime :
 		this.seeMorphMerlin = this.Loader.GetValue<Option, bool>(Option.SeeMorphMerlin);
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateCommonAbilityOption(
             factory, 30.0f);
 		factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Smasher.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Smasher.cs
@@ -105,9 +105,9 @@ public sealed class Smasher : SingleRoleBase, IRoleAutoBuildAbility
         killer.killTimer = this.prevKillCool;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 1, 14);
 

--- a/ExtremeRoles/Roles/Solo/Impostor/SpecialImpostor.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/SpecialImpostor.cs
@@ -13,8 +13,9 @@ public sealed class SpecialImpostor : SingleRoleBase
         true, false, true, true)
     {}
 
-    protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         return;
     }
 

--- a/ExtremeRoles/Roles/Solo/Impostor/Terorist.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Terorist.cs
@@ -67,9 +67,9 @@ public sealed class Terorist : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         IRoleAbility.CreateAbilityCountOption(
             factory, 5, 100);
 		factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/Thief.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Thief.cs
@@ -130,9 +130,9 @@ public sealed class Thief : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(
             factory, 2, 5, 2.0f);
 		factory.CreateFloatOption(ThiefOption.Range, 0.1f, 1.8f, 3.6f, 0.1f);

--- a/ExtremeRoles/Roles/Solo/Impostor/TimeBreaker.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/TimeBreaker.cs
@@ -52,8 +52,9 @@ public sealed class TimeBreaker : SingleRoleBase, IRoleAutoBuildAbility
 		return true;
 	}
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(
 			factory, 2, 100);
 		factory.CreateFloatOption(

--- a/ExtremeRoles/Roles/Solo/Impostor/UnderWarper.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/UnderWarper.cs
@@ -334,9 +334,9 @@ public sealed class UnderWarper :
         return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             UnderWarperOption.AwakeKillCount,
             1, 0, 5, 1,

--- a/ExtremeRoles/Roles/Solo/Impostor/Zombie.cs
+++ b/ExtremeRoles/Roles/Solo/Impostor/Zombie.cs
@@ -422,9 +422,9 @@ public sealed class Zombie :
     public override bool IsBlockShowPlayingRoleInfo() => this.infoBlock();
 
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateIntOption(
             ZombieOption.AwakeKillCount,
             1, 0, 3, 1,

--- a/ExtremeRoles/Roles/Solo/Neutral/Alice.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Alice.cs
@@ -189,9 +189,9 @@ public sealed class Alice :
 		}
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             AliceOption.CanUseSabotage,
             true);

--- a/ExtremeRoles/Roles/Solo/Neutral/Artist.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Artist.cs
@@ -146,9 +146,9 @@ public sealed class Artist :
 		}
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			ArtistOption.CanUseVent,
 			false);

--- a/ExtremeRoles/Roles/Solo/Neutral/Eater.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Eater.cs
@@ -299,10 +299,9 @@ public sealed class Eater : SingleRoleBase, IRoleAutoBuildAbility, IRoleMurderPl
     public override bool IsSameTeam(SingleRoleBase targetRole) =>
         this.IsNeutralSameTeam(targetRole);
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
-
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             EaterOption.CanUseVent,
             true);

--- a/ExtremeRoles/Roles/Solo/Neutral/Hatter.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Hatter.cs
@@ -130,9 +130,9 @@ public sealed class Hatter : SingleRoleBase, IRoleAutoBuildAbility, IRoleUpdate
 		return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 		   HatterOption.CanRepairSabotage,
 		   false);

--- a/ExtremeRoles/Roles/Solo/Neutral/Heretic.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Heretic.cs
@@ -285,9 +285,9 @@ public sealed class Heretic :
 		return base.GetTargetRoleSeeColor(targetRole, targetPlayerId);
 	}
 
-	protected override void CreateSpecificOption(
-		AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(Option.UseVent, false);
 		var taskOpt = factory.CreateBoolOption(
 			Option.HasTask,

--- a/ExtremeRoles/Roles/Solo/Neutral/Jester.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Jester.cs
@@ -122,9 +122,9 @@ public sealed class Jester : SingleRoleBase, IRoleAutoBuildAbility
         OutburstKill(this.outburstTarget.PlayerId, killTarget.PlayerId);
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             JesterOption.OutburstDistance,
             1.0f, 0.0f, 2.0f, 0.1f);

--- a/ExtremeRoles/Roles/Solo/Neutral/Miner.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Miner.cs
@@ -332,9 +332,9 @@ public sealed class Miner :
     public override bool IsSameTeam(SingleRoleBase targetRole) =>
         this.IsNeutralSameTeam(targetRole);
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			MinerOption.LinkingAllVent,
 			false);

--- a/ExtremeRoles/Roles/Solo/Neutral/Monika.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Monika.cs
@@ -100,9 +100,9 @@ public sealed class Monika :
 		return true;
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			Ops.IsSoloTeam, true);
 		factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Neutral/TaskMaster.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/TaskMaster.cs
@@ -117,9 +117,9 @@ public sealed class TaskMaster : SingleRoleBase, IRoleSpecialSetUp, IRoleUpdate
         resetTask(rolePlayer.PlayerId);
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             TaskMasterOption.CanUseSabotage,
             true);

--- a/ExtremeRoles/Roles/Solo/Neutral/TotoCalcio.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/TotoCalcio.cs
@@ -181,10 +181,9 @@ public sealed class Totocalcio : SingleRoleBase, IRoleAutoBuildAbility, IRoleWin
         return base.GetRolePlayerNameTag(targetRole, targetPlayerId);
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
-
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             TotocalcioOption.Range,
             1.0f, 0.0f, 2.0f, 0.1f);

--- a/ExtremeRoles/Roles/Solo/Neutral/Umbrer.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Umbrer.cs
@@ -327,9 +327,9 @@ public sealed class Umbrer : SingleRoleBase, IRoleAutoBuildAbility, IRoleSpecial
         }
     }
 
-    protected override void CreateSpecificOption(
-        AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateFloatOption(
             UmbrerOption.Range,
             1.0f, 0.1f, 4.0f, 0.1f);


### PR DESCRIPTION
NeutralおよびImpostorに属する全役職クラスにおいて、`CreateSpecificOption`メソッドのシグネチャを`AutoParentSetOptionCategoryFactory factory`から`OptionCategoryScope<AutoParentSetBuilder> categoryScope`を使用する新しい形式に更新しました。

メソッド内では`categoryScope.Builder`を`factory`という名前の一時変数に格納することで、既存のコードへの影響を最小限に留めています。