### PR TITLE
Refactor(Neutral, Impostor): CreateSpecificOptionのAPIを新しいものに移行

### DIFF
--- a/ExtremeRoles/Roles/Solo/Neutral/Jackal/FurryRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Jackal/FurryRole.cs
@@ -131,8 +131,9 @@ public sealed class FurryRole : SingleRoleBase,
 		ExtremeRoleManager.SetNewRole(targetFurry, newJackal);
 	}
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(Option.UseVent, false);
 		var taskOpt = factory.CreateBoolOption(
 			Option.HasTask, false);

--- a/ExtremeRoles/Roles/Solo/Neutral/Jackal/ShepherdRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Jackal/ShepherdRole.cs
@@ -93,8 +93,9 @@ public sealed class ShepherdRole : SingleRoleBase, IRoleWinPlayerModifier, IRole
 		}
 	}
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		var killOpt = factory.CreateBoolOption(
 			Option.CanKill, true);
 		CreateKillerOption(factory, killOpt, true, true);

--- a/ExtremeRoles/Roles/Solo/Neutral/Queen/KnightRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Queen/KnightRole.cs
@@ -110,8 +110,9 @@ public sealed class KnightRole : SingleRoleBase, IRoleWinPlayerModifier, IRoleUp
 				ColorPalette.QueenWhite :
 				base.GetTargetRoleSeeColor(targetRole, targetPlayerId);
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			Option.IsSubTeam, true);
 		factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Neutral/Queen/PawnRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Queen/PawnRole.cs
@@ -64,8 +64,9 @@ public sealed class PawnRole : SingleRoleBase, IRoleWinPlayerModifier, IRoleUpda
 				ColorPalette.QueenWhite :
 				base.GetTargetRoleSeeColor(targetRole, targetPlayerId);
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(
 			Option.UseVent, false);
 		var taskOpt = factory.CreateBoolOption(

--- a/ExtremeRoles/Roles/Solo/Neutral/Queen/QueenRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Queen/QueenRole.cs
@@ -431,8 +431,9 @@ public sealed class QueenRole :
         }
     }
 
-    protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+    protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
     {
+        var factory = categoryScope.Builder;
         factory.CreateBoolOption(
             QueenOption.CanUseVent,
             false);

--- a/ExtremeRoles/Roles/Solo/Neutral/Tucker/TuckerRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Tucker/TuckerRole.cs
@@ -254,8 +254,9 @@ public sealed class TuckerRole :
 		}
 	}
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		IRoleAbility.CreateAbilityCountOption(factory, 1, 10);
 
 		factory.CreateFloatOption(

--- a/ExtremeRoles/Roles/Solo/Neutral/Yandere/IntimateRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Yandere/IntimateRole.cs
@@ -101,8 +101,9 @@ public sealed class IntimateRole : SingleRoleBase, IRoleWinPlayerModifier, IRole
 				ColorPalette.YandereVioletRed :
 				base.GetTargetRoleSeeColor(targetRole, targetPlayerId);
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		var killOpt = factory.CreateBoolOption(
 			Option.CanKill, true);
 		CreateKillerOption(factory, killOpt, true, true);

--- a/ExtremeRoles/Roles/Solo/Neutral/Yandere/SurrogatorRole.cs
+++ b/ExtremeRoles/Roles/Solo/Neutral/Yandere/SurrogatorRole.cs
@@ -156,8 +156,9 @@ public sealed class SurrogatorRole :
 			gurdNum);
 	}
 
-	protected override void CreateSpecificOption(AutoParentSetOptionCategoryFactory factory)
+	protected override void CreateSpecificOption(OptionCategoryScope<AutoParentSetBuilder> categoryScope)
 	{
+		var factory = categoryScope.Builder;
 		factory.CreateBoolOption(Option.UseVent, false);
 		var taskOpt = factory.CreateBoolOption(
 			Option.HasTask, false);


### PR DESCRIPTION
NeutralおよびImpostorに属する全役職クラスにおいて、`CreateSpecificOption`メソッドのシグネチャを`AutoParentSetOptionCategoryFactory factory`から`OptionCategoryScope<AutoParentSetBuilder> categoryScope`を使用する新しい形式に更新しました。

サブディレクトリ内のファイルもすべて更新済みです。

メソッド内では`categoryScope.Builder`を`factory`という名前の一時変数に格納することで、既存のコードへの影響を最小限に留めています。

## issueへのリンク
<!-- このPull requestによって修正される不具合または追加機能について議論されているissueの番号を＃をつけて記載、ない場合は修正される不具合または追加機能についてのissueを作成した上でPull requestをお願いします 例:#7 -->

## レビュワーに確認してほしいこと
<!-- このコードを見る全ての人(主にyukieiji)に対して確認してほしい事 -->

## チェックリスト
<!-- 以下のチェックリストはほぼマストです。確認をお願いします -->
- [] : ホストで追加する機能や役職、能力が使えることを確認した
- [] : ホスト以外で追加する機能や役職、能力が使えることを確認した
- [] : 役職の能力に関して会議が挟まる、サイドキックにされる等で正しくリセットされることを確認した

### 追加チェックリスト
<!-- これはコードの品質を保つためのチェックリストです、やってなくても構いません -->
- [] : 変数名に代入される値は妥当であるか
- [] : メソッド、関数名に相応しくない処理をしていないか
- [] : メソッド、関数は長くなりすぎてないか
- [] : 機能や役職の変数、メソッドのアクセシビリティレベルは妥当であるか(publicを多用していないか)
- [] : 機能や役職のデータ構造は妥当だと思われるものを使用しているか
