### PR TITLE
Add various English translations

### DIFF
--- a/ExtremeRoles/Translation/resx/Combination.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Combination.en-US.resx
@@ -1106,4 +1106,90 @@ Button ability "SKATE":
   <data name="SkaterSkateOff" xml:space="preserve">
     <value>Cancel SKATE</value>
   </data>
+  <data name="AssassinCanKilledFromLiberal" xml:space="preserve">
+    <value>Assasin: Can be Killed by LIBERALS</value>
+  </data>
+  <data name="Barter" xml:space="preserve">
+    <value>Barter</value>
+  </data>
+  <data name="BarterAwakeDeadPlayerNum" xml:space="preserve">
+    <value>"AWAKE" : Dead players required</value>
+  </data>
+  <data name="BarterAwakeKillNum" xml:space="preserve">
+    <value>"AWAKE" : Kills required</value>
+  </data>
+  <data name="BarterAwakeTaskRate" xml:space="preserve">
+    <value>"AWAKE" : Task completion rate required</value>
+  </data>
+  <data name="BarterCanCallMeeting" xml:space="preserve">
+    <value>Can call emergency meeting</value>
+  </data>
+  <data name="BarterCastlingInfo" xml:space="preserve">
+    <value>Show notification on Castling</value>
+  </data>
+  <data name="BarterCastlingNum" xml:space="preserve">
+    <value>"CASTLING" : Ability Charges</value>
+  </data>
+  <data name="BarterFullDescription" xml:space="preserve">
+    <value>A role with the ability to exchange positions with others.
+The target's actions except movement will be cancelled upon exchange.
+After awakening, the KILL button changes to "CASTLING" and can be used a specified number of times.</value>
+  </data>
+  <data name="BarterIntroDescription" xml:space="preserve">
+    <value>Equivalent exchange.</value>
+  </data>
+  <data name="BarterMaxCastlingNumWhenMeeting" xml:space="preserve">
+    <value>"CASTLING" : Max charges per meeting</value>
+  </data>
+  <data name="BarterOneCastlingNum" xml:space="preserve">
+    <value>"CASTLING" : Number of charges per use</value>
+  </data>
+  <data name="BarterRandomCastling" xml:space="preserve">
+    <value>Random Castling if no target is nearby</value>
+  </data>
+  <data name="BarterRandomCastlingLabel" xml:space="preserve">
+    <value>Not specified</value>
+  </data>
+  <data name="BarterShortDescription" xml:space="preserve">
+    <value>Exchange positions with others</value>
+  </data>
+  <data name="BarterShowCastlingOther" xml:space="preserve">
+    <value>Notify the target about the exchange</value>
+  </data>
+  <data name="EvilBarter" xml:space="preserve">
+    <value>Evil Barter</value>
+  </data>
+  <data name="GuesserCanCrewmate" xml:space="preserve">
+    <value>Can guess Crewmate roles</value>
+  </data>
+  <data name="GuesserCanDove" xml:space="preserve">
+    <value>Can guess Dove roles</value>
+  </data>
+  <data name="GuesserCanImpostor" xml:space="preserve">
+    <value>Can guess Impostor roles</value>
+  </data>
+  <data name="GuesserCanMilitant" xml:space="preserve">
+    <value>Can guess Militant roles</value>
+  </data>
+  <data name="GuesserGuessDefaultRoleMode" xml:space="preserve">
+    <value>Default role guessing method</value>
+  </data>
+  <data name="InvestigatorContinueSearch" xml:space="preserve">
+    <value>Continue "INVESTIGATE" after meeting</value>
+  </data>
+  <data name="InvestigatorForceMeetingOnSearchEnd" xml:space="preserve">
+    <value>Force meeting when "INVESTIGATE" completes</value>
+  </data>
+  <data name="InvestigatorSearchCanContineMeetingNum" xml:space="preserve">
+    <value>Max meetings to continue "INVESTIGATE"</value>
+  </data>
+  <data name="InvestigatorSearchCanFindName" xml:space="preserve">
+    <value>Include player name in cause of death when "INVESTIGATE" completes</value>
+  </data>
+  <data name="MarlinCanSeeLiberal" xml:space="preserve">
+    <value>Merlin: Can see the Liberal faction</value>
+  </data>
+  <data name="NiceBarter" xml:space="preserve">
+    <value>Nice Barter</value>
+  </data>
 </root>

--- a/ExtremeRoles/Translation/resx/Crewmate.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Crewmate.en-US.resx
@@ -1273,4 +1273,277 @@ Ability "Forced Report":
   <data name="forceReportUntil" xml:space="preserve">
     <value>{0} seconds until forced report</value>
   </data>
+  <data name="BlockModeAbilityAndKillButton" xml:space="preserve">
+    <value>All Buttons</value>
+  </data>
+  <data name="BlockModeAbilityAndReportButton" xml:space="preserve">
+    <value>Ability and Report Buttons</value>
+  </data>
+  <data name="BlockModeAbilityButton" xml:space="preserve">
+    <value>Ability Button only</value>
+  </data>
+  <data name="BlockModeAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="BlockModeKillAndReportButton" xml:space="preserve">
+    <value>Kill and Report Buttons</value>
+  </data>
+  <data name="BlockModeKillButton" xml:space="preserve">
+    <value>Kill Button only</value>
+  </data>
+  <data name="BlockModeNone" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="BlockModeReportButton" xml:space="preserve">
+    <value>Report Button only</value>
+  </data>
+  <data name="CEO" xml:space="preserve">
+    <value>CEO</value>
+  </data>
+  <data name="CEOAwakeTaskGage" xml:space="preserve">
+    <value>"AWAKE" : Task completion rate required</value>
+  </data>
+  <data name="CEOExiledOverride" xml:space="preserve">
+    <value>Override victory conditions on CEO's exile</value>
+  </data>
+  <data name="CEOFullDescription" xml:space="preserve">
+    <value>The Captain.
+"AWAKE" by completing tasks to dominate meetings.
+You can see who voted for whom during meetings.
+When exiled, you take the person who voted for you with you.</value>
+  </data>
+  <data name="CEOIntroDescription" xml:space="preserve">
+    <value>I will take responsibility for this ship.</value>
+  </data>
+  <data name="CEOIsShowRolePlayerVote" xml:space="preserve">
+    <value>Can see who voted for whom</value>
+  </data>
+  <data name="CEOIsUseCEOMeeting" xml:space="preserve">
+    <value>Enable special meetings</value>
+  </data>
+  <data name="CEOMeetingCEO" xml:space="preserve">
+    <value>You don't need to decide.&lt;br&gt;I will decide.</value>
+  </data>
+  <data name="CEOMeetingOther" xml:space="preserve">
+    <value>Watch the Captain's decision&lt;br&gt;in silence.</value>
+  </data>
+  <data name="CEOMeetingSelect" xml:space="preserve">
+    <value>Please choose who to exile</value>
+  </data>
+  <data name="CEOMeetingSkip" xml:space="preserve">
+    <value>Skip?</value>
+  </data>
+  <data name="CEOShortDescription" xml:space="preserve">
+    <value>Exile the Impostors and save the ship</value>
+  </data>
+  <data name="Echo" xml:space="preserve">
+    <value>Echo</value>
+  </data>
+  <data name="EchoAbilityCoolTime" xml:space="preserve">
+    <value>"ECHOLOCATION" : Ability Cooldown</value>
+  </data>
+  <data name="EchoAbilityCount" xml:space="preserve">
+    <value>"ECHOLOCATION" : Ability Charges</value>
+  </data>
+  <data name="EchoAttentionMode" xml:space="preserve">
+    <value>"ECHOLOCATION" : Notification mode</value>
+  </data>
+  <data name="EchoCanSeparatePlayer" xml:space="preserve">
+    <value>Notify individually when multiple players are detected</value>
+  </data>
+  <data name="EchoFullDescription" xml:space="preserve">
+    <value>A Crewmate who finds players by sound.
+
+Button Ability "ECHOLOCATION":
+- Detects players within a certain range.
+- Notifications vary depending on the distance to the nearest player.
+- Visualizes the position with an icon.
+- Can also detect corpses depending on settings.
+  - If notifications are separated, the icon for a detected corpse will be red.</value>
+  </data>
+  <data name="EchoIntroDescription" xml:space="preserve">
+    <value>Where is your sound from?</value>
+  </data>
+  <data name="EchoIsDetectDeadBody" xml:space="preserve">
+    <value>"ECHOLOCATION" : Can detect corpses</value>
+  </data>
+  <data name="EchoRange" xml:space="preserve">
+    <value>"ECHOLOCATION" : Ability Range</value>
+  </data>
+  <data name="EchoShortDescription" xml:space="preserve">
+    <value>Find players' positions with "ECHOLOCATION"</value>
+  </data>
+  <data name="EchoShowTime" xml:space="preserve">
+    <value>"ECHOLOCATION" : Notification duration</value>
+  </data>
+  <data name="EmitAll" xml:space="preserve">
+    <value>Notify all players</value>
+  </data>
+  <data name="EmitNotCrewmate" xml:space="preserve">
+    <value>Notify non-Crewmates</value>
+  </data>
+  <data name="Exorcist" xml:space="preserve">
+    <value>Exorcist</value>
+  </data>
+  <data name="ExorcistAbility" xml:space="preserve">
+    <value>Exorcism</value>
+  </data>
+  <data name="ExorcistAbilityActiveTime" xml:space="preserve">
+    <value>"EXORCISM" : Time required</value>
+  </data>
+  <data name="ExorcistAbilityCoolTime" xml:space="preserve">
+    <value>"EXORCISM" : Ability Cooldown</value>
+  </data>
+  <data name="ExorcistAbilityCount" xml:space="preserve">
+    <value>"EXORCISM" : Ability Charges</value>
+  </data>
+  <data name="ExorcistAwakeTaskGage" xml:space="preserve">
+    <value>Task completion rate to be misrecognized as an Impostor</value>
+  </data>
+  <data name="ExorcistCrewBlockSystemType" xml:space="preserve">
+    <value>Disadvantage during "EXORCISM"</value>
+  </data>
+  <data name="ExorcistFullDescription" xml:space="preserve">
+    <value>A Crewmate who is displayed as an Impostor to Impostors.
+However, must complete tasks above the "Task completion rate to be misrecognized as an Impostor".
+
+Cannot use the report button.
+
+Button Ability "EXORCISM":
+- Activate by targeting a nearby corpse.
+- After a set time, an automatic report occurs and corpse information is output to the chat.
+- While the ability is active, a "Disadvantage during EXORCISM" is applied to the entire Crewmate faction.</value>
+  </data>
+  <data name="ExorcistIntroDescription" xml:space="preserve">
+    <value>Defeat the Impostors with holy power</value>
+  </data>
+  <data name="ExorcistRange" xml:space="preserve">
+    <value>"EXORCISM" : Distance from corpse to activate</value>
+  </data>
+  <data name="ExorcistReport" xml:space="preserve">
+    <value>"{0}" seems to have died by "{1}", the culprit is "{2}"</value>
+  </data>
+  <data name="ExorcistReportWithName" xml:space="preserve">
+    <value>{1} was killed by "{0}", the cause is "{2}"</value>
+  </data>
+  <data name="ExorcistShortDescription" xml:space="preserve">
+    <value>Get advantageous information with "EXORCISM"</value>
+  </data>
+  <data name="ExorcistWithName" xml:space="preserve">
+    <value>Include killer's name in "EXORCISM" information</value>
+  </data>
+  <data name="GamblerChangeVoteChance" xml:space="preserve">
+    <value>Chance of vote count changing</value>
+  </data>
+  <data name="GamblerFullDescription" xml:space="preserve">
+    <value>A Crewmate role whose vote count randomly changes between 1 and a specified range.
+This change is not visible on screen, and the displayed vote count will always be 1 (internally it is calculated).
+If the chance hits, the vote count changes randomly between the maximum and minimum values.</value>
+  </data>
+  <data name="GamblerMaxVoteNum" xml:space="preserve">
+    <value>Maximum vote count</value>
+  </data>
+  <data name="GamblerMinVoteNum" xml:space="preserve">
+    <value>Minimum vote count</value>
+  </data>
+  <data name="Inspector" xml:space="preserve">
+    <value>Inspector</value>
+  </data>
+  <data name="InspectorAbilityActiveTime" xml:space="preserve">
+    <value>"INSPECT" : Ability Duration</value>
+  </data>
+  <data name="InspectorAbilityCoolTime" xml:space="preserve">
+    <value>"INSPECT" : Ability Cooldown</value>
+  </data>
+  <data name="InspectorAbilityCount" xml:space="preserve">
+    <value>"INSPECT" : Ability Charges</value>
+  </data>
+  <data name="InspectorFullDescription" xml:space="preserve">
+    <value>A Crewmate who detects specified actions.
+
+Button Ability: "INSPECT"
+- Activate by pressing the button.
+- Detects players who performed specific actions during the duration.
+- Displays an arrow to those players.
+- Arrows are only displayed while the ability is active.</value>
+  </data>
+  <data name="InspectorInspectAbility" xml:space="preserve">
+    <value>Detect ability usage</value>
+  </data>
+  <data name="InspectorInspectSabotage" xml:space="preserve">
+    <value>Detect Sabotage</value>
+  </data>
+  <data name="InspectorInspectVent" xml:space="preserve">
+    <value>Detect Vent usage</value>
+  </data>
+  <data name="InspectorIntroDescription" xml:space="preserve">
+    <value>All actions are exposed, point to the truth of the moment</value>
+  </data>
+  <data name="InspectorShortDescription" xml:space="preserve">
+    <value>Expose those who did "specific actions"</value>
+  </data>
+  <data name="Loner" xml:space="preserve">
+    <value>Loner</value>
+  </data>
+  <data name="LonerArrowNum" xml:space="preserve">
+    <value>Number of arrows to show</value>
+  </data>
+  <data name="LonerArrowShowVentPlayer" xml:space="preserve">
+    <value>Show arrows to players in vents</value>
+  </data>
+  <data name="LonerFullDescription" xml:space="preserve">
+    <value>A Crewmate whose "Stress Level" increases when players are nearby, and who suicides if it exceeds a certain value.
+
+Stress Level: {0}/{1}
+
+Passive Ability "Stress":
+- "Stress Level" increases when players are within range.
+- Increase rate is 1 stress/second/person.
+- "Stress Level" decreases by 1 per second when no players are in range.</value>
+  </data>
+  <data name="LonerIntroDescription" xml:space="preserve">
+    <value>A proud but somewhat lonely lone Crewmate</value>
+  </data>
+  <data name="LonerIsShowArrow" xml:space="preserve">
+    <value>Show arrows to nearby players</value>
+  </data>
+  <data name="LonerShortDescription" xml:space="preserve">
+    <value>Don't let your "Stress Level" get too high</value>
+  </data>
+  <data name="LonerStressIgnoreTime" xml:space="preserve">
+    <value>Time after spawning during which "Stress Level" does not increase</value>
+  </data>
+  <data name="LonerStressMaxGage" xml:space="preserve">
+    <value>"Stress Level" to suicide</value>
+  </data>
+  <data name="LonerStressProgressOnMovingPlatPlayer" xml:space="preserve">
+    <value>Increase "Stress Level" for players using ladders, etc.</value>
+  </data>
+  <data name="LonerStressProgressOnTask" xml:space="preserve">
+    <value>Increase "Stress Level" during tasks</value>
+  </data>
+  <data name="LonerStressProgressOnVentPlayer" xml:space="preserve">
+    <value>Increase "Stress Level" for players in vents</value>
+  </data>
+  <data name="LonerStressRange" xml:space="preserve">
+    <value>"Stress Level" increase range</value>
+  </data>
+  <data name="SheriffCanShootLiberal" xml:space="preserve">
+    <value>Can kill "LIBERAL"</value>
+  </data>
+  <data name="TeleporterInitAbilityNum" xml:space="preserve">
+    <value>"SET PORTAL" : Initial Charges</value>
+  </data>
+  <data name="echoLocation" xml:space="preserve">
+    <value>ECHOLOCATION</value>
+  </data>
+  <data name="inspect" xml:space="preserve">
+    <value>INSPECT</value>
+  </data>
+  <data name="inspectArrowWarning" xml:space="preserve">
+    <value>The "INSPECTOR" found your position!!</value>
+  </data>
+  <data name="inspectSystem" xml:space="preserve">
+    <value> usage is being monitored...</value>
+  </data>
 </root>

--- a/ExtremeRoles/Translation/resx/Impostor.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Impostor.en-US.resx
@@ -1601,4 +1601,76 @@ Button ability "TIME BREAK":
   <data name="timeBreakerTimeBreak" xml:space="preserve">
     <value>TIME BREAK</value>
   </data>
+  <data name="Boxer" xml:space="preserve">
+    <value>Boxer</value>
+  </data>
+  <data name="BoxerAbility" xml:space="preserve">
+    <value>STRAIGHT</value>
+  </data>
+  <data name="BoxerAbilityCoolTime" xml:space="preserve">
+    <value>"STRAIGHT" : Ability Cooldown</value>
+  </data>
+  <data name="BoxerAbilityCount" xml:space="preserve">
+    <value>"STRAIGHT" : Ability Charges</value>
+  </data>
+  <data name="BoxerFullDescription" xml:space="preserve">
+    <value>An Impostor who can kill Crewmates by launching them with "STRAIGHT".&#xA;&#xA;Button Ability "STRAIGHT":&#xA;- When activated, charging begins.&#xA;- If a player is nearby during charging, you can press it again.&#xA;- When pressed again, it launches that player.&#xA;- If the launched player hits a wall above a certain speed, they are killed.&#xA;- Launch speed varies depending on the charge rate.</value>
+  </data>
+  <data name="BoxerIntroDescription" xml:space="preserve">
+    <value>Deliver a lethal "STRAIGHT" punch</value>
+  </data>
+  <data name="BoxerShortDescription" xml:space="preserve">
+    <value>Launch Crewmates with "STRAIGHT" to kill them</value>
+  </data>
+  <data name="BoxerStraightAcceleration" xml:space="preserve">
+    <value>Launched Crewmate's acceleration</value>
+  </data>
+  <data name="BoxerStraightChargeTime" xml:space="preserve">
+    <value>"STRAIGHT" : Charging time</value>
+  </data>
+  <data name="BoxerStraightFirstSpeed" xml:space="preserve">
+    <value>Launched Crewmate's initial speed</value>
+  </data>
+  <data name="BoxerStraightKillSpeed" xml:space="preserve">
+    <value>Speed at which death occurs on wall impact</value>
+  </data>
+  <data name="BoxerStraightRange" xml:space="preserve">
+    <value>"STRAIGHT" : Ability Distance</value>
+  </data>
+  <data name="BoxerStraightReflectionE" xml:space="preserve">
+    <value>Coefficient of restitution on wall impact</value>
+  </data>
+  <data name="GetFirstWeapon" xml:space="preserve">
+    <value>Obtained "{0}"</value>
+  </data>
+  <data name="GetNextWeapon" xml:space="preserve">
+    <value>Obtained "{0}", can switch with mouse wheel</value>
+  </data>
+  <data name="Legislator" xml:space="preserve">
+    <value>Legislator</value>
+  </data>
+  <data name="LegislatorChargeVotePerOtherVote" xml:space="preserve">
+    <value>Negative votes charged per vote</value>
+  </data>
+  <data name="LegislatorDefaultVoteNum" xml:space="preserve">
+    <value>Default number of negative votes</value>
+  </data>
+  <data name="LegislatorFullDescription" xml:space="preserve">
+    <value>An Impostor who accumulates others' votes and can cancel out the target's votes.&#xA;&#xA;Meeting Ability: "Negative Vote"&#xA;- Activate by selecting a player during a meeting.&#xA;- Cancels out that player's votes by the number of "Negative Votes".&#xA;- Negative votes increase based on votes cast for anyone except the person this role voted for.&#xA;  Increase amount: (Total votes for others) x Set conversion rate</value>
+  </data>
+  <data name="LegislatorIncludeSkipVote" xml:space="preserve">
+    <value>Count skip votes as negative votes</value>
+  </data>
+  <data name="LegislatorIntroDescription" xml:space="preserve">
+    <value>Majority rule is the height of folly; I make the true decision.</value>
+  </data>
+  <data name="LegislatorShortDescription" xml:space="preserve">
+    <value>Accumulate negative votes and cancel out votes</value>
+  </data>
+  <data name="WeaponMixInfo" xml:space="preserve">
+    <value>Weapon synthesis possible with "Alt" key</value>
+  </data>
+  <data name="legislatorVoteStatus" xml:space="preserve">
+    <value>Ability active: {0}&#xA;Current negative votes: {1}</value>
+  </data>
 </root>

--- a/ExtremeRoles/Translation/resx/Liberal.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Liberal.en-US.resx
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <data name="LeaderFullDescription" xml:space="preserve">
+    <value>Type: Dove/Militant (depending on settings)
+Considered a Dove if tasks are assigned, and a Militant if a kill button is assigned.
+
+Current funds are displayed next to the player's name.
+This role always exists when the Liberal faction is assigned.
+This role cannot be targeted by abilities under any circumstances.
+If "Allow Kills on Leader" is OFF, all kills against the Leader are invalidated.
+Behavior changes with the following settings:
+- If "Allow Kills when Liberal faction is only the Leader" is ON, the Leader can be killed when they are the last remaining member of the Liberal faction.
+- If "Auto-Eliminate when Liberal faction is only the Leader" is ON, the Leader automatically dies when they are the last remaining member of the Liberal faction. Auto-revival will not occur in this case.
+
+Settings labeled "Fund Increase Rate Increase" permanently increase the multiplier for funds gained by all Liberal faction members when the Leader enters specific situations.
+Example:
+"Militant - Fund Increase Rate Increase per Kill": 5
+"Leader - Fund Increase Rate Increase per Kill": 10
+"Leader - Fund Bonus per Kill": 10%
+1. When the Leader starts killing, the fund increase rate increases by 10%, and funds increase by 11 (10 * 1.1).
+2. Subsequently, when a Liberal Militant kills, funds increase by 5.5 (5 * 1.1).</value>
+  </data>
+  <data name="LeaderShortDescription" xml:space="preserve">
+    <value>Symbol of Revolution</value>
+  </data>
+  <data name="LeaderIntroDescription" xml:space="preserve">
+    <value>Lead the Liberal faction as the Leader</value>
+  </data>
+  <data name="DoveFullDescription" xml:space="preserve">
+    <value>Type: Dove
+
+Gains funds by completing tasks.
+Tasks are added indefinitely.</value>
+  </data>
+  <data name="DoveShortDescription" xml:space="preserve">
+    <value>Achieve revolution through tasks</value>
+  </data>
+  <data name="DoveIntroDescription" xml:space="preserve">
+    <value>What is needed for revolution is "dialogue"</value>
+  </data>
+  <data name="MilitantFullDescription" xml:space="preserve">
+    <value>Type: Militant
+
+Gains funds for activities by killing.</value>
+  </data>
+  <data name="MilitantShortDescription" xml:space="preserve">
+    <value>Achieve revolution through kills</value>
+  </data>
+  <data name="MilitantIntroDescription" xml:space="preserve">
+    <value>What is needed for revolution is "overwhelming power"</value>
+  </data>
+</root>

--- a/ExtremeRoles/Translation/resx/Neutral.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Neutral.en-US.resx
@@ -1478,4 +1478,28 @@ Victory Condition: Queen's victory (including special victories).</value>
   <data name="AllQueenWin" xml:space="preserve">
     <value>Thanks to Knight's efforts, all Queen team</value>
   </data>
+  <data name="HereticMeetingButtonTaskGage" xml:space="preserve">
+    <value>Task completion rate to enable "EMERGENCY MEETING" button</value>
+  </data>
+  <data name="HereticUseVent" xml:space="preserve">
+    <value>Can use Vents</value>
+  </data>
+  <data name="IntimateCanKillOneSideLover" xml:space="preserve">
+    <value>Can kill "SWEETIE" when "YANDERE" is visible</value>
+  </data>
+  <data name="IntimateCanKillYandere" xml:space="preserve">
+    <value>Can kill "YANDERE" when "YANDERE" is visible</value>
+  </data>
+  <data name="KnightCanKillQueen" xml:space="preserve">
+    <value>Can kill "QUEEN" when "QUEEN" is visible</value>
+  </data>
+  <data name="KnightCanKillServant" xml:space="preserve">
+    <value>Can kill "SERVANT" when "QUEEN" is visible</value>
+  </data>
+  <data name="ShepherdCanKillJackal" xml:space="preserve">
+    <value>Can kill "JACKAL" when "JACKAL" is visible</value>
+  </data>
+  <data name="ShepherdCanKillSidekick" xml:space="preserve">
+    <value>Can kill "SIDEKICK" when "JACKAL" is visible</value>
+  </data>
 </root>

--- a/ExtremeRoles/Translation/resx/Text.en-US.resx
+++ b/ExtremeRoles/Translation/resx/Text.en-US.resx
@@ -1244,4 +1244,154 @@ Do you want to continue Installing?</value>
   <data name="Viper" xml:space="preserve">
     <value>Viper</value>
   </data>
+  <data name="AddOnKill" xml:space="preserve">
+    <value>Kill</value>
+  </data>
+  <data name="AddOnTask" xml:space="preserve">
+    <value>Task</value>
+  </data>
+  <data name="Clashed" xml:space="preserve">
+    <value>Clashed</value>
+  </data>
+  <data name="Despair" xml:space="preserve">
+    <value>Despair</value>
+  </data>
+  <data name="Dove" xml:space="preserve">
+    <value>Dove</value>
+  </data>
+  <data name="Leader" xml:space="preserve">
+    <value>Leader</value>
+  </data>
+  <data name="Liberal" xml:space="preserve">
+    <value>Liberal</value>
+  </data>
+  <data name="LiberalSetting" xml:space="preserve">
+    <value>Liberal Common Settings</value>
+  </data>
+  <data name="LiberalSettingCanHasTaskLeader" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Has tasks</value>
+  </data>
+  <data name="LiberalSettingCanKillLeader" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Has kill button</value>
+  </data>
+  <data name="LiberalSettingCanKilledLeader" xml:space="preserve">
+    <value>Allow Kills on Leader</value>
+  </data>
+  <data name="LiberalSettingCanKilledWhenLeaderSolo" xml:space="preserve">
+    <value>Allow Kills when Liberal faction is only the Leader</value>
+  </data>
+  <data name="LiberalSettingIsAutoExitWhenLeaderSolo" xml:space="preserve">
+    <value>Auto-Eliminate when Liberal faction is only the Leader</value>
+  </data>
+  <data name="LiberalSettingIsAutoRevive" xml:space="preserve">
+    <value>Leader's Auto-Revival</value>
+  </data>
+  <data name="LiberalSettingKillMoney" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Militant&lt;/color&gt;&#xA;Fund Bonus per Kill</value>
+  </data>
+  <data name="LiberalSettingLeaderHasOtherKillCool" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Has modified Kill Cooldown</value>
+  </data>
+  <data name="LiberalSettingLeaderHasOtherKillRange" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Has modified Kill Distance</value>
+  </data>
+  <data name="LiberalSettingLeaderHasOtherVisonSize" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Has special vision settings</value>
+  </data>
+  <data name="LiberalSettingLeaderKillBoost" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Fund Increase Rate Increase per Kill</value>
+  </data>
+  <data name="LiberalSettingLeaderKillCool" xml:space="preserve">
+    <value>Kill Cooldown</value>
+  </data>
+  <data name="LiberalSettingLeaderKillMoney" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Fund Bonus per Kill</value>
+  </data>
+  <data name="LiberalSettingLeaderKillRange" xml:space="preserve">
+    <value>Kill Distance</value>
+  </data>
+  <data name="LiberalSettingLeaderKilledBoost" xml:space="preserve">
+    <value>Fund Increase Rate Increase&#xA;(When Leader is killed)</value>
+  </data>
+  <data name="LiberalSettingLeaderTaskBoost" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Fund Increase Rate Increase per Task completion</value>
+  </data>
+  <data name="LiberalSettingLeaderTaskCompletedMoney" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Leader&lt;/color&gt;&#xA;Fund Bonus per Task completion</value>
+  </data>
+  <data name="LiberalSettingLeaderVison" xml:space="preserve">
+    <value>Vision</value>
+  </data>
+  <data name="LiberalSettingLiberalMilitantMax" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Militant&lt;/color&gt;&#xA;Maximum number of roles</value>
+  </data>
+  <data name="LiberalSettingLiberalMilitantMini" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Militant&lt;/color&gt;&#xA;Minimum number of roles</value>
+  </data>
+  <data name="LiberalSettingLiberalVison" xml:space="preserve">
+    <value>Vision</value>
+  </data>
+  <data name="LiberalSettingMilitantHasOtherKillCool" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Militant&lt;/color&gt;&#xA;Has modified Kill Cooldown</value>
+  </data>
+  <data name="LiberalSettingMilitantHasOtherKillRange" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Militant&lt;/color&gt;&#xA;Has modified Kill Distance</value>
+  </data>
+  <data name="LiberalSettingMilitantKillCool" xml:space="preserve">
+    <value>Kill Cooldown</value>
+  </data>
+  <data name="LiberalSettingMilitantKillRange" xml:space="preserve">
+    <value>Kill Distance</value>
+  </data>
+  <data name="LiberalSettingTaskCompletedMoney" xml:space="preserve">
+    <value>&lt;color=#F9F06F&gt;Dove&lt;/color&gt;&#xA;Fund Bonus per Task completion</value>
+  </data>
+  <data name="LiberalSettingUseVent" xml:space="preserve">
+    <value>Global Vents</value>
+  </data>
+  <data name="LiberalSettingWinMoney" xml:space="preserve">
+    <value>Funds required for victory</value>
+  </data>
+  <data name="Militant" xml:space="preserve">
+    <value>Militant</value>
+  </data>
+  <data name="RoleSpawnCategoryMaxLiberal" xml:space="preserve">
+    <value>Maximum number of Liberal roles</value>
+  </data>
+  <data name="RoleSpawnCategoryMinLiberal" xml:space="preserve">
+    <value>Minimum number of Liberal roles</value>
+  </data>
+  <data name="ShowOnlyActiveRoleInInfoOverlay" xml:space="preserve">
+    <value>Display only configured roles</value>
+  </data>
+  <data name="buttonAbility" xml:space="preserve">
+    <value>Button Ability</value>
+  </data>
+  <data name="liberalGlobalInfo" xml:space="preserve">
+    <value>&lt;size=135%&gt;Liberal Description&lt;/size&gt;&#xA;A faction centered around the special role "Leader", composed of Doves and Militants.&#xA;As a common setting for this faction, they are not affected by vision effects like blackouts.&#xA;&#xA;- Victory Conditions:&#xA;  1. Accumulate funds above the set value&#xA;  2. All survivors become Liberal (no majority victory)&#xA;&#xA;- Special Role "Leader"&#xA;  A role that is always assigned when the Liberal faction is assigned.&#xA;  Basically invincible.&#xA;  Fund status is displayed next to this player's name.&#xA;  See Leader's role information for details.&#xA;&#xA;- Dove&#xA;  Refers to Liberal roles that have tasks, noted as "Type: Dove" or "Dove".&#xA;  Tasks are added indefinitely.&#xA;  The default role name for "Type: Dove" is also "Dove".&#xA;&#xA;- Militant&#xA;  Refers to Liberal roles that have a kill button, noted as "Type: Militant" or "Militant".&#xA;  The default role name for "Type: Militant" is also "Militant".</value>
+  </data>
+  <data name="liberalIntro0" xml:space="preserve">
+    <value>Those who reject bondage and gather under the name of "Liberty"</value>
+  </data>
+  <data name="liberalIntro1" xml:space="preserve">
+    <value>Be the blade of innovation that cuts through stagnation</value>
+  </data>
+  <data name="liberalIntro2" xml:space="preserve">
+    <value>Our weapon is reason; bring true change through debate</value>
+  </data>
+  <data name="liberalMoneySummaryInfo" xml:space="preserve">
+    <value>Liberal Fund Balance</value>
+  </data>
+  <data name="liberalRoles" xml:space="preserve">
+    <value>"Liberal" Roles</value>
+  </data>
+  <data name="liberalShotCall" xml:space="preserve">
+    <value>Revolutionary</value>
+  </data>
+  <data name="sabotageKey" xml:space="preserve">
+    <value>Sabotage</value>
+  </data>
+  <data name="ventKey" xml:space="preserve">
+    <value>Vent</value>
+  </data>
 </root>


### PR DESCRIPTION
This change adds comprehensive English localization for several roles and a new faction (Liberal) that were previously missing English strings. Key roles updated include Barter, CEO, Echo, Exorcist, Boxer, and Legislator. Typo consistency with the existing codebase (e.g., "Assasin" and "Marlin") has been maintained where necessary for functional correctness of the string lookups.

---
*PR created automatically by Jules for task [17409024989341798890](https://jules.google.com/task/17409024989341798890) started by @yukieiji*