### PR TITLE
ReadyToMergeラベル自動付与アクションの追加

### DIFF
--- a/.github/workflows/label-ready-to-merge.yml
+++ b/.github/workflows/label-ready-to-merge.yml
@@ -1,12 +1,11 @@
 name: Label Ready to Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened, synchronize]
 
 permissions:
   pull-requests: write
-  issues: write
 
 jobs:
   label:
@@ -14,12 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Add ReadyToMerge label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['ReadyToMerge']
-            })
+        run: gh pr edit "$PR_URL" --add-label "ReadyToMerge"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
PR作成時またはドラフト解除時に、ドラフト状態でなければ「ReadyToMerge」ラベルを自動的に付与するGitHub Actionsワークフローを追加しました。これにより、ビルドチェックなどの自動化処理が円滑に開始されるようになります。

---
*PR created automatically by Jules for task [17829330705866598170](https://jules.google.com/task/17829330705866598170) started by @yukieiji*