### PR TITLE
ビルド失敗時にコメント投稿後にワークフローを失敗させる変更

### DIFF
--- a/.github/workflows/autoBuildAndTransCheck.yml
+++ b/.github/workflows/autoBuildAndTransCheck.yml
@@ -46,12 +46,12 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: RunBuild
         id: build
-        continue-on-error: true
         run: msbuild ExtremeRoles.sln -t:restore,build -p:Configuration=Release -p:RestorePackagesConfig=true
       - name: CheckTransData
-        continue-on-error: true
+        if: always() && steps.build.outcome != 'skipped'
         run: python createtransdatareport.py ${{ steps.build.outcome }}
       - name: PostComment
+        if: always() && steps.build.outcome != 'skipped'
         uses: thollander/actions-comment-pull-request@v3
         with:
             github-token: ${{ steps.gen_token.outputs.token }}


### PR DESCRIPTION
Modify the `autoBuildAndTransCheck` workflow to fail the status check if `RunBuild` fails, while still ensuring that the translation report is generated and posted as a comment.

Key changes:
- Removed `continue-on-error: true` from `RunBuild` and `CheckTransData` steps.
- Added `if: always() && steps.build.outcome != 'skipped'` to `CheckTransData` and `PostComment` steps.
- This ensures the workflow reflects failure as soon as `RunBuild` ends if it fails, but continues to post the report comment before terminating.

---
*PR created automatically by Jules for task [6603816383693478570](https://jules.google.com/task/6603816383693478570) started by @yukieiji*