### PR TITLE
Add /au/translation/ GET API endpoint

### DIFF
--- a/ExtremeRoles/ExtremeRolesPlugin.cs
+++ b/ExtremeRoles/ExtremeRolesPlugin.cs
@@ -117,6 +117,7 @@ public partial class ExtremeRolesPlugin : BasePlugin
 		ApiServer.Register("/au/chat/", HttpMethod.Get, new GetChat());
 		ApiServer.Register("/au/option/", HttpMethod.Get, new GetAuOption());
 		ApiServer.Register("/au/option/", HttpMethod.Put, new PutAuOption());
+		ApiServer.Register("/au/translation/", HttpMethod.Get, new GetTranslation());
 		ApiServer.Register(PostChat.Path, HttpMethod.Post, new PostChat());
 		ApiServer.Register(ChatWebUI.Path, HttpMethod.Get, new OpenChatWebUi());
 		ApiServer.Register(ConectGame.Path, HttpMethod.Get, new ConectGame());

--- a/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
+++ b/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
@@ -69,11 +69,23 @@ public sealed class GetTranslation : IRequestHandler
 			{
 				if (p.ValueKind == JsonValueKind.Number)
 				{
-					if (p.TryGetInt32(out int i)) return (object)i;
-					if (p.TryGetDouble(out double d)) return (object)d;
+					if (p.TryGetInt32(out int i))
+					{
+						return (object)i;
+					}
+					if (p.TryGetDouble(out double d))
+					{
+						return (object)d;
+					}
 				}
-				if (p.ValueKind == JsonValueKind.True) return (object)true;
-				if (p.ValueKind == JsonValueKind.False) return (object)false;
+				if (p.ValueKind == JsonValueKind.True)
+				{
+					return (object)true;
+				}
+				if (p.ValueKind == JsonValueKind.False)
+				{
+					return (object)false;
+				}
 				return (object)(p.GetString() ?? p.ToString());
 			}).ToArray(),
 			translated

--- a/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
+++ b/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
@@ -56,9 +56,15 @@ public sealed class GetTranslation : IRequestHandler
 			keyObj = intKey;
 			translated = TranslationController.Instance.GetString((StringNames)intKey, partsArray);
 		}
-		else
+		else if (req.Key.ValueKind == JsonValueKind.String)
 		{
 			string strKey = req.Key.GetString() ?? "";
+			keyObj = strKey;
+			translated = Tr.GetString(strKey, partsArray);
+		}
+		else
+		{
+			string strKey = req.Key.ToString();
 			keyObj = strKey;
 			translated = Tr.GetString(strKey, partsArray);
 		}
@@ -86,7 +92,11 @@ public sealed class GetTranslation : IRequestHandler
 				{
 					return (object)false;
 				}
-				return (object)(p.GetString() ?? p.ToString());
+				if (p.ValueKind == JsonValueKind.String)
+				{
+					return (object)(p.GetString() ?? "");
+				}
+				return (object)p.ToString();
 			}).ToArray(),
 			translated
 		);

--- a/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
+++ b/ExtremeRoles/Module/ApiHandler/GetTranslation.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+
+using ExtremeRoles.Module.Interface;
+using ExtremeRoles.Extension.Controller;
+using Il2CppObject = Il2CppSystem.Object;
+
+namespace ExtremeRoles.Module.ApiHandler;
+
+public readonly record struct GetTranslationRequest(JsonElement Key, JsonElement[]? Param);
+
+public readonly record struct GetTranslationResponse(object Key, object[] Param, string Result);
+
+public sealed class GetTranslation : IRequestHandler
+{
+	public Action<HttpListenerContext> Request => this.requestAction;
+
+	private void requestAction(HttpListenerContext context)
+	{
+		var response = context.Response;
+
+		GetTranslationRequest req;
+		try
+		{
+			req = IRequestHandler.DeserializeJson<GetTranslationRequest>(context.Request);
+		}
+		catch (Exception)
+		{
+			IRequestHandler.SetStatusNG(response);
+			response.Close();
+			return;
+		}
+
+		object keyObj;
+		string translated = "";
+
+		var parts = new List<Il2CppObject>();
+		if (req.Param != null)
+		{
+			foreach (var p in req.Param)
+			{
+				// Convert to Il2CppObject.
+				// Strings are implicitly converted to Il2CppSystem.String.
+				// For numbers, we convert to string to be safe as seen in other parts of the codebase.
+				parts.Add((Il2CppObject)p.ToString());
+			}
+		}
+
+		var partsArray = parts.ToArray();
+
+		if (req.Key.ValueKind == JsonValueKind.Number && req.Key.TryGetInt32(out int intKey))
+		{
+			keyObj = intKey;
+			translated = TranslationController.Instance.GetString((StringNames)intKey, partsArray);
+		}
+		else
+		{
+			string strKey = req.Key.GetString() ?? "";
+			keyObj = strKey;
+			translated = Tr.GetString(strKey, partsArray);
+		}
+
+		var result = new GetTranslationResponse(
+			keyObj,
+			(req.Param ?? Array.Empty<JsonElement>()).Select(p =>
+			{
+				if (p.ValueKind == JsonValueKind.Number)
+				{
+					if (p.TryGetInt32(out int i)) return (object)i;
+					if (p.TryGetDouble(out double d)) return (object)d;
+				}
+				if (p.ValueKind == JsonValueKind.True) return (object)true;
+				if (p.ValueKind == JsonValueKind.False) return (object)false;
+				return (object)(p.GetString() ?? p.ToString());
+			}).ToArray(),
+			translated
+		);
+
+		IRequestHandler.SetStatusOK(response);
+		IRequestHandler.SetContentsType(response);
+		IRequestHandler.Write(response, result);
+	}
+}


### PR DESCRIPTION
Added a new GET API endpoint `/au/translation/` to the `ApiServer`.
This endpoint allows external tools to retrieve translated strings from the game and the mod.
It accepts a JSON body with `Key` (int or string) and `Param` (array of mixed types).
- If `Key` is an integer, it's treated as a `StringNames` enum value.
- If `Key` is a string, it's treated as a custom translation key.
- `Param` values are used for string formatting.
- The response returns the original `Key`, `Param`, and the resulting `Result` string.

---
*PR created automatically by Jules for task [8563292612935321579](https://jules.google.com/task/8563292612935321579) started by @yukieiji*