### PR TITLE
Add /au/translation/batch/optionunit endpoint

### DIFF
--- a/ExtremeRoles/ExtremeRolesPlugin.cs
+++ b/ExtremeRoles/ExtremeRolesPlugin.cs
@@ -119,6 +119,7 @@ public partial class ExtremeRolesPlugin : BasePlugin
 		ApiServer.Register("/au/option/", HttpMethod.Put, new PutAuOption());
 		ApiServer.Register("/au/translation/", HttpMethod.Get, new GetTranslation());
 		ApiServer.Register("/au/translation/batch/", HttpMethod.Get, new GetTranslationBatch());
+		ApiServer.Register("/au/translation/batch/optionunit", HttpMethod.Get, new GetTranslationOptionUnit());
 		ApiServer.Register(PostChat.Path, HttpMethod.Post, new PostChat());
 		ApiServer.Register(ChatWebUI.Path, HttpMethod.Get, new OpenChatWebUi());
 		ApiServer.Register(ConectGame.Path, HttpMethod.Get, new ConectGame());

--- a/ExtremeRoles/Module/ApiHandler/GetTranslationOptionUnit.cs
+++ b/ExtremeRoles/Module/ApiHandler/GetTranslationOptionUnit.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+using ExtremeRoles.Module.Interface;
+using ExtremeRoles.Extension.Controller;
+
+namespace ExtremeRoles.Module.ApiHandler;
+
+public sealed class GetTranslationOptionUnit : IRequestHandler
+{
+	public Action<HttpListenerContext> Request => this.requestAction;
+
+	private void requestAction(HttpListenerContext context)
+	{
+		var response = context.Response;
+
+		var units = Enum.GetValues<OptionUnit>();
+		var results = new List<GetTranslationResponse>();
+
+		foreach (var unit in units)
+		{
+			string key = unit.ToString();
+			string translated;
+			if (unit == OptionUnit.None)
+			{
+				translated = string.Empty;
+			}
+			else
+			{
+				translated = Tr.GetString(key);
+				translated = translated.Replace("{0}", string.Empty);
+			}
+
+			results.Add(new GetTranslationResponse(key, Array.Empty<object>(), translated));
+		}
+
+		IRequestHandler.SetStatusOK(response);
+		IRequestHandler.SetContentsType(response);
+		IRequestHandler.Write(response, results.ToArray());
+	}
+}


### PR DESCRIPTION
Add a new GET endpoint `/au/translation/batch/optionunit` that returns the translated names of all `OptionUnit` values. The results are returned as an array of `GetTranslationResponse` objects, matching the format of other translation batch APIs. 

Key implementation details:
- `OptionUnit.None` returns an empty string.
- Other units have their `{0}` placeholder removed from the translated string.
- All enum values are included in the response.

---
*PR created automatically by Jules for task [482848123654931847](https://jules.google.com/task/482848123654931847) started by @yukieiji*